### PR TITLE
Use Rust stable toolchain

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
       ];
       perSystem = { config, self', inputs', system, pkgs, lib, ... }:
         let
-          rustToolchain = inputs'.fenix.packages.complete.toolchain;
+          rustToolchain = inputs'.fenix.packages.stable.toolchain;
           craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 
           kairosNodeAttrs = {


### PR DESCRIPTION
Unless we have explicit reason to use nightly toolchain, we should stick to stable one.