### PR TITLE
Replace `PublicKey` and `Signature` with plain `Vec<u8>`

### DIFF
--- a/kairos-server/src/lib.rs
+++ b/kairos-server/src/lib.rs
@@ -9,8 +9,8 @@ use state::LockedBatchState;
 
 pub use errors::AppErr;
 
-type PublicKey = String;
-type Signature = String;
+type PublicKey = Vec<u8>;
+type Signature = Vec<u8>;
 
 pub fn app_router(state: LockedBatchState) -> Router {
     Router::new()

--- a/kairos-server/src/routes/deposit.rs
+++ b/kairos-server/src/routes/deposit.rs
@@ -42,7 +42,7 @@ pub async fn deposit_handler(
     *balance = updated_balance;
 
     tracing::info!(
-        "Updated account public_key={} balance={}",
+        "Updated account public_key={:?} balance={}",
         public_key,
         updated_balance
     );

--- a/kairos-server/src/routes/withdraw.rs
+++ b/kairos-server/src/routes/withdraw.rs
@@ -63,7 +63,7 @@ pub async fn withdraw_handler(
     }
 
     tracing::info!(
-        "Updated account public_key={} balance={}",
+        "Updated account public_key={:?} balance={}",
         withdrawal.public_key,
         updated_balance
     );


### PR DESCRIPTION
Fix for #31 - we want to rely on bytes, not strings. Additionally, using type aliases at this point has no value.