### PR TITLE
kairos-cli: fix use of deprecated function

### DIFF
--- a/kairos-cli/src/common/args.rs
+++ b/kairos-cli/src/common/args.rs
@@ -4,12 +4,12 @@ use clap::Args;
 
 #[derive(Args, Debug)]
 pub struct AmountArg {
-    #[arg(name = "amount", long, short, value_name = "NUM_MOTES")]
+    #[arg(id = "amount", long, short, value_name = "NUM_MOTES")]
     pub field: u64,
 }
 
 #[derive(Args, Debug)]
 pub struct PrivateKeyPathArg {
-    #[arg(name = "private-key", long, short = 'k', value_name = "FILE_PATH")]
+    #[arg(id = "private-key", long, short = 'k', value_name = "FILE_PATH")]
     pub field: PathBuf,
 }


### PR DESCRIPTION
`#[arg(name)] was allowed by mistake, instead use `#[arg(id)]` or `#[arg(value_name)]`
closes #37 