### PR TITLE
ci: don't cancel other platform jobs on failure

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,7 @@ jobs:
   check:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, macos-14 ]
     steps:


### PR DESCRIPTION
- allows other architecture cu-runs to complete and provide feedback