### PR TITLE
Enable `clap` feature for reporting deprecation

### DIFF
--- a/kairos-cli/Cargo.toml
+++ b/kairos-cli/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 casper-types = { version = "4.0.1", features = ["std"] } # TODO: Change `std` -> `std-fs-io` in the future version.
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "deprecated"] }
 hex = "0.4"
 thiserror = "1"
 


### PR DESCRIPTION
There is interesting `clap`'s [optional feature](https://docs.rs/clap/latest/clap/_features/index.html#optional-features) that we should enable:

> - deprecated: Guided experience to prepare for next breaking release (at different stages of development, this may become default)

This would trigger the warnings like this reported in https://github.com/cspr-rad/kairos/issues/37:

```
warning: use of deprecated function `<common::args::AmountArg as clap::Args>::augment_args::id_is_only_for_arg`: `#[arg(name)] was allowed by mistake, instead use `#[arg(id
)]` or `#[arg(value_name)]`
```