### PR TITLE
Clarify dual licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,16 @@ To run a single check e.g. the format check, run:
 ```sh
 nix build .#checks.<system>.treefmt
 ```
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ at your option.
 
 ### Contribution
 
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
This PR clarifies dual licensing, by adding extra **License** section to `README`.

**Briefly put:**

- Contributions are made with Apache  2.0 license (unless stated otherwise).
- Users can use this software either as MIT **or** Apache 2.0.
 
---

### Related resources

- https://internals.rust-lang.org/t/rationale-of-apache-dual-licensing/8952/4
- https://github.com/sfackler/rust-postgres-macros/issues/19
- https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields