### PR TITLE
Add `no_std` support to `kairos-tx`

### DIFF
--- a/.github/workflows/extra-check.yml
+++ b/.github/workflows/extra-check.yml
@@ -1,0 +1,21 @@
+name: extra-check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # https://github.com/cspr-rad/kairos/pull/61#issuecomment-2035637388
+  build-kairos-tx-without-std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Build no_std version of `kairos-tx`
+        run: cargo build -p kairos-tx --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,7 +1749,6 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "rasn",
- "thiserror",
 ]
 
 [[package]]

--- a/kairos-tx/Cargo.toml
+++ b/kairos-tx/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 [dependencies]
 num-traits = "0.2"
 rasn = { version = "0.12", default-features = false, features = ["macros"] }
-thiserror = "1"
 
 [features]
 default = ["std"]

--- a/kairos-tx/Cargo.toml
+++ b/kairos-tx/Cargo.toml
@@ -10,3 +10,7 @@ license.workspace = true
 num-traits = "0.2"
 rasn = { version = "0.12", default-features = false, features = ["macros"] }
 thiserror = "1"
+
+[features]
+default = ["std"]
+std = []

--- a/kairos-tx/src/asn.rs
+++ b/kairos-tx/src/asn.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::error::TxError;
 
 // Expose types for the public API.

--- a/kairos-tx/src/error.rs
+++ b/kairos-tx/src/error.rs
@@ -1,21 +1,48 @@
-use rasn::error::{DecodeError, EncodeError};
-use thiserror::Error;
+use core::fmt;
 
-#[derive(Error, Debug)]
+use rasn::error::{DecodeError, EncodeError};
+
+#[derive(Debug)]
 pub enum TxError {
     /// Errors related to encoding.
-    #[error("encode error: {0}")]
     EncodeError(EncodeError),
 
     /// Errors related to decoding.
-    #[error("decode error: {0}")]
     DecodeError(DecodeError),
 
     /// Constraint violation for a specific field.
-    #[error("constraint violated for '{field}'")]
     ConstraintViolation { field: &'static str },
 
     /// Signature verification failure.
-    #[error("signature verification failed")]
     InvalidSignature,
 }
+
+impl fmt::Display for TxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TxError::EncodeError(e) => write!(f, "encode error: {e}"),
+            TxError::DecodeError(e) => write!(f, "decode error: {e}"),
+            TxError::ConstraintViolation { field } => {
+                write!(f, "constraint violated for '{field}'")
+            }
+            TxError::InvalidSignature => write!(f, "signature verification failed"),
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+mod error {
+    use super::*;
+    use core::fmt::{Debug, Display};
+
+    pub trait Error: Debug + Display {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            None
+        }
+    }
+
+    impl Error for TxError {}
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TxError {}

--- a/kairos-tx/src/helpers.rs
+++ b/kairos-tx/src/helpers.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::asn::{
     Amount, Deposit, Nonce, PublicKey, SigningPayload, TransactionBody, Transfer, Withdrawal,
 };

--- a/kairos-tx/src/lib.rs
+++ b/kairos-tx/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
 pub mod asn;
 pub mod error;
 pub mod helpers;

--- a/kairos-tx/src/lib.rs
+++ b/kairos-tx/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 extern crate alloc;
 
 pub mod asn;


### PR DESCRIPTION
This PR adds support for `no_std` in `kairos-tx` :rocket:.

**Note:** I replaced `thiserror` with plain enum implementing `fmt::Display`, as advised by @Avi-D-coder :clap:.

Closes #60.