### PR TITLE
Fix broken e2e tests for server requests

### DIFF
--- a/kairos-server/src/routes/mod.rs
+++ b/kairos-server/src/routes/mod.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct PayloadBody {
+    #[serde(deserialize_with = "hex_to_vec", serialize_with = "vec_to_hex")]
     pub public_key: PublicKey,
     #[serde(deserialize_with = "hex_to_vec", serialize_with = "vec_to_hex")]
     pub payload: Vec<u8>,

--- a/nixos/tests/end-to-end.nix
+++ b/nixos/tests/end-to-end.nix
@@ -46,14 +46,33 @@ nixosTest {
 
     kairos.succeed("casper-client get-node-status --node-address http://localhost:11101")
 
-    deposit_request = { "public_key": "publickey", "amount": 10 }
+    # Tx Payload
+    #   nonce = 1
+    #   deposit:
+    #     amount = 1000
+    #
+    deposit_payload = "3009020101a004020203e8"
+    deposit_request = { "public_key": "deadbeef", "payload": deposit_payload, "signature": "cafebabe" }
     # REST API
     client.succeed("curl --fail-with-body -X POST http://kairos/api/v1/deposit -H 'Content-Type: application/json' -d '{}'".format(json.dumps(deposit_request)))
 
-    transfer_request = { "from": "publickey", "signature": "signature", "to": "publickey", "amount": 10 }
+    # Tx Payload
+    #   nonce = 2
+    #   transfer:
+    #     recipient = DEADBEEF
+    #     amount = 1000
+    #
+    transfer_payload = "300f020102a10a0404deadbeef020203e8"
+    transfer_request = { "public_key": "deadbeef", "payload": transfer_payload, "signature": "cafebabe" }
     client.succeed("curl --fail-with-body -X POST http://kairos/api/v1/transfer -H 'Content-Type: application/json' -d '{}'".format(json.dumps(transfer_request)))
 
-    withdraw_request = { "public_key": "publickey", "signature": "signature", "amount": 10 }
+    # Tx Payload
+    #   nonce = 3
+    #   withdrawal:
+    #     amount = 1000
+    #
+    withdraw_payload = "3009020103a204020203e8"
+    withdraw_request = { "public_key": "deadbeef", "payload": withdraw_payload, "signature": "cafebabe" }
     client.succeed("curl --fail-with-body -X POST http://kairos/api/v1/withdraw -H 'Content-Type: application/json' -d '{}'".format(json.dumps(withdraw_request)))
 
     # CLI with ed25519


### PR DESCRIPTION
Fixes on top of #59:

- https://github.com/cspr-rad/kairos/pull/65/commits/e5193f109d55d9a233a200c8055081dae30054e7 - Handle public key as hexstring.
- https://github.com/cspr-rad/kairos/pull/65/commits/94d3af986163d6d2d1abcb0958a534b24d2d4bf3 - Update tx payload to the new format.