### PR TITLE
flake: explicit source filtering

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,11 +48,20 @@
             src = lib.cleanSourceWith {
               src = craneLib.path ./.;
               filter = path: type:
-                !(builtins.elem (builtins.baseNameOf path) [ "kairos-contracts" "nixos" "kairos-prover" ]) &&
-                # Allow static files.
-                (lib.hasInfix "/fixtures/" path) ||
-                # Default filter (from crane) for .rs files.
-                (craneLib.filterCargoSources path type)
+                (builtins.any (includePath: lib.hasInfix includePath path) [
+                  "/kairos-cli"
+                  "/kairos-crypto"
+                  "/kairos-server"
+                  "/kairos-test-utils"
+                  "/kairos-tx"
+                  "/Cargo.toml"
+                  "/Cargo.lock"
+                ]) && (
+                  # Allow static files.
+                  (lib.hasInfix "/tests/fixtures/" path) ||
+                  # Default filter (from crane) for .rs files.
+                  (craneLib.filterCargoSources path type)
+                )
               ;
             };
             nativeBuildInputs = with pkgs; [ pkg-config ];


### PR DESCRIPTION
This PR introduces a more explicit source filtering for the kairos-node related workspace.
We currently have 3 workspaces in this monorepo, this has 2 reasons:
- the risc0 toolchain is different from the one we need for kairos and it is quite big. We do not want to rebuild risc0 in every nix build when a source changes
- nix wants clear separation of host and target platforms for cross-compilation

Since the other two workspaces are located in `kairos-prover` and `kairos-contracts`, and both of them are a subdirectory of the `kairos` workspace, and we say `src = ./.` with nix for the `kairos` workspace, any change of sources which are not related to `kairos`, will trigger a nix rebuild, since the changed sources cause the hash of the derivation to change.

with source filtering we can avoid the hash to change if we modify files which are not relevant to our kairos workspace.
 
This is the trace output when building kairos now. `true` indicates that the file is considered during the build and that it impacts the derivation hash.
```
...0v17-kairos/.editorconfig = false
...0v17-kairos/.github = false
...0v17-kairos/.gitignore = false
...0v17-kairos/Cargo.lock = true
...0v17-kairos/Cargo.toml = true
...0v17-kairos/LICENSE-APACHE = false
...0v17-kairos/LICENSE-MIT = false
...0v17-kairos/README.md = false
...0v17-kairos/flake.lock = false
...0v17-kairos/flake.nix = false
...0v17-kairos/kairos-cli = true
...0v17-kairos/kairos-cli/Cargo.toml = true
...0v17-kairos/kairos-cli/bin = true
...0v17-kairos/kairos-cli/bin/main.rs = true
...0v17-kairos/kairos-cli/src = true
...0v17-kairos/kairos-cli/src/commands = true
...0v17-kairos/kairos-cli/src/commands/deposit.rs = true
...0v17-kairos/kairos-cli/src/commands/mod.rs = true
...0v17-kairos/kairos-cli/src/commands/transfer.rs = true
...0v17-kairos/kairos-cli/src/commands/withdraw.rs = true
...0v17-kairos/kairos-cli/src/common = true
...0v17-kairos/kairos-cli/src/common/args.rs = true
...0v17-kairos/kairos-cli/src/common/mod.rs = true
...0v17-kairos/kairos-cli/src/error.rs = true
...0v17-kairos/kairos-cli/src/lib.rs = true
...0v17-kairos/kairos-cli/src/utils.rs = true
...0v17-kairos/kairos-cli/tests = true
...0v17-kairos/kairos-cli/tests/cli_tests.rs = true
...0v17-kairos/kairos-cli/tests/fixtures = true
...0v17-kairos/kairos-cli/tests/fixtures/ed25519 = true
...0v17-kairos/kairos-cli/tests/fixtures/ed25519/public_key.pem = true
...0v17-kairos/kairos-cli/tests/fixtures/ed25519/secret_key.pem = true
...0v17-kairos/kairos-cli/tests/fixtures/invalid.pem = true
...0v17-kairos/kairos-cli/tests/fixtures/secp256k1 = true
...0v17-kairos/kairos-cli/tests/fixtures/secp256k1/public_key.pem = true
...0v17-kairos/kairos-cli/tests/fixtures/secp256k1/secret_key.pem = true
...0v17-kairos/kairos-crypto = true
...0v17-kairos/kairos-crypto/Cargo.toml = true
...0v17-kairos/kairos-crypto/src = true
...0v17-kairos/kairos-crypto/src/error.rs = true
...0v17-kairos/kairos-crypto/src/implementations = true
...0v17-kairos/kairos-crypto/src/implementations/casper.rs = true
...0v17-kairos/kairos-crypto/src/implementations/mod.rs = true
...0v17-kairos/kairos-crypto/src/lib.rs = true
...0v17-kairos/kairos-prover = false
...0v17-kairos/kairos-server = true
...0v17-kairos/kairos-server/.env = false
...0v17-kairos/kairos-server/Cargo.toml = true
...0v17-kairos/kairos-server/src = true
...0v17-kairos/kairos-server/src/config.rs = true
...0v17-kairos/kairos-server/src/errors.rs = true
...0v17-kairos/kairos-server/src/lib.rs = true
...0v17-kairos/kairos-server/src/main.rs = true
...0v17-kairos/kairos-server/src/routes = true
...0v17-kairos/kairos-server/src/routes/deposit.rs = true               
...0v17-kairos/kairos-server/src/routes/mod.rs = true                   
...0v17-kairos/kairos-server/src/routes/transfer.rs = true
...0v17-kairos/kairos-server/src/routes/withdraw.rs = true
...0v17-kairos/kairos-server/src/state.rs = true
...0v17-kairos/kairos-server/src/utils.rs = true
...0v17-kairos/kairos-server/tests = true              
...0v17-kairos/kairos-server/tests/transactions.rs = true        
...0v17-kairos/kairos-test-utils = true
...0v17-kairos/kairos-test-utils/Cargo.toml = true
...0v17-kairos/kairos-test-utils/bin = true
...0v17-kairos/kairos-test-utils/bin/cctld.rs = true
...0v17-kairos/kairos-test-utils/src = true
...0v17-kairos/kairos-test-utils/src/cctl = true
...0v17-kairos/kairos-test-utils/src/cctl/parsers.rs = true
...0v17-kairos/kairos-test-utils/src/cctl.rs = true
...0v17-kairos/kairos-test-utils/src/lib.rs = true
...0v17-kairos/kairos-tx = true
...0v17-kairos/kairos-tx/Cargo.toml = true
...0v17-kairos/kairos-tx/schema.asn = false
...0v17-kairos/kairos-tx/src = true
...0v17-kairos/kairos-tx/src/asn.rs = true
...0v17-kairos/kairos-tx/src/error.rs = true
...0v17-kairos/kairos-tx/src/helpers.rs = true
...0v17-kairos/kairos-tx/src/lib.rs = true
...0v17-kairos/nixos = false
...0v17-kairos/Cargo.lock = true

```