### PR TITLE
flake/coverage: remove -Cstrip=none rust flag

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710734606,
-        "narHash": "sha256-rFJl+WXfksu2NkWJWKGd5Km17ZGEjFg9hOQNwstsoU8=",
+        "lastModified": 1713128889,
+        "narHash": "sha256-aB90ZqzosyRDpBh+rILIcyP5lao8SKz8Sr2PSWvZrzk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79bb4155141a5e68f2bdee2bf6af35b1d27d3a1d",
+        "rev": "2748d22b45a99fb2deafa5f11c7531c212b2cefa",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -149,23 +149,38 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1713013257,
+        "narHash": "sha256-ZEfGB3YCBVggvk0BQIqVY7J8XF/9jxQ68fCca6nib+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90055d5e616bd943795d38808c94dbf0dd35abe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "risc0pkgs": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1705057078,
-        "narHash": "sha256-IvTD2yh6vYFKgvBATOl793csHbu2Vki3D19MKCHp8sk=",
+        "lastModified": 1707207642,
+        "narHash": "sha256-EjzGyFHs+hpSuvOjNnVBx48V5h5whRIyAjIUgSOzqLk=",
         "owner": "cspr-rad",
         "repo": "risc0pkgs",
-        "rev": "144c9a42850a245f581db2586208cd18f98ff62b",
+        "rev": "7acff27ce7116777cc7f5a162efa9b599808ed97",
         "type": "github"
       },
       "original": {
         "owner": "cspr-rad",
         "repo": "risc0pkgs",
+        "rev": "7acff27ce7116777cc7f5a162efa9b599808ed97",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,10 @@
     crane.inputs.nixpkgs.follows = "nixpkgs";
     advisory-db.url = "github:rustsec/advisory-db";
     advisory-db.flake = false;
-    risc0pkgs.url = "github:cspr-rad/risc0pkgs";
-    risc0pkgs.inputs.nixpkgs.follows = "nixpkgs";
+    # Pin to a revision with working risc0 build
+    risc0pkgs.url = "github:cspr-rad/risc0pkgs/7acff27ce7116777cc7f5a162efa9b599808ed97";
+    # FIXME once we are able to build with upstream rustc we should uncomment this
+    #risc0pkgs.inputs.nixpkgs.follows = "nixpkgs";
     csprpkgs.url = "github:cspr-rad/csprpkgs/add-cctl";
     csprpkgs.inputs.nixpkgs.follows = "nixpkgs";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -150,14 +150,11 @@
             coverage-report = craneLib.cargoTarpaulin (kairosNodeAttrs // {
               cargoArtifacts = self'.packages.kairos-deps;
 
-              # FIXME fix weird issue with rust-nightly and tarpaulin https://github.com/xd009642/tarpaulin/issues/1499
-              RUSTFLAGS = "-Cstrip=none";
-
               # Default values from https://crane.dev/API.html?highlight=tarpau#cranelibcargotarpaulin
               # --avoid-cfg-tarpaulin fixes nom/bitvec issue https://github.com/xd009642/tarpaulin/issues/756#issuecomment-838769320
               cargoTarpaulinExtraArgs = "--skip-clean --out xml --output-dir $out --avoid-cfg-tarpaulin";
-              # For some reason cargoTarpaulin runs the tests in the buildPhase
 
+              # For some reason cargoTarpaulin runs the tests in the buildPhase
               buildInputs = kairosNodeAttrs.buildInputs ++ [
                 inputs'.csprpkgs.packages.cctl
               ];

--- a/kairos-contracts/demo-contract-tests/tests/integration_tests.rs
+++ b/kairos-contracts/demo-contract-tests/tests/integration_tests.rs
@@ -2,7 +2,7 @@ mod test_fixture;
 #[cfg(test)]
 mod tests {
     use crate::test_fixture::TestContext;
-    use casper_types::{account::AccountHash, Key, U512};
+    use casper_types::{account::AccountHash, U512};
 
     #[test]
     fn should_install_deposit_contract() {


### PR DESCRIPTION
The pipeline for [53899b1](https://github.com/cspr-rad/kairos/pull/69/commits/53899b17aa17acab4a45e7d1c1ed147a5e4fa945) should fail ([see pipeline error](https://hercules-ci.com/accounts/github/cspr-rad/derivations/%2Fnix%2Fstore%2Fvydscd7a14b82l99ksg9gln44mipwi8q-kairos-tarpaulin-0.1.0.drv/log?via-job=a539e130-30d6-4084-9981-a41914c5306b))

After updating to tarpaulin 0.28 (see [release notes](https://github.com/xd009642/tarpaulin/releases/tag/0.28.0), which is achieved by updating nixpkgs, this flag is not required anymore (see [succeeding build](https://hercules-ci.com/accounts/github/cspr-rad/derivations/%2Fnix%2Fstore%2Fhnfhz9zx8xkd2jzc9n9w80y21z1mczcm-kairos-tarpaulin-0.1.0.drv?via-job=763a17b9-022e-4e61-ac16-573abee52f1f))