### PR TITLE
Test feature sets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ name = "kairos"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-

--- a/flake.nix
+++ b/flake.nix
@@ -121,14 +121,14 @@
           checks = {
             lint = craneLib.cargoClippy (kairosNodeAttrs // {
               cargoArtifacts = self'.packages.kairos-deps;
-              cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+              cargoClippyExtraArgs = "--features=all-tests --all-targets -- --deny warnings";
             });
 
             coverage-report = craneLib.cargoTarpaulin (kairosNodeAttrs // {
               cargoArtifacts = self'.packages.kairos-deps;
               # Default values from https://crane.dev/API.html?highlight=tarpau#cranelibcargotarpaulin
               # --avoid-cfg-tarpaulin fixes nom/bitvec issue https://github.com/xd009642/tarpaulin/issues/756#issuecomment-838769320
-              cargoTarpaulinExtraArgs = "--skip-clean --out xml --output-dir $out --avoid-cfg-tarpaulin";
+              cargoTarpaulinExtraArgs = "--features=all-tests --skip-clean --out xml --output-dir $out --avoid-cfg-tarpaulin";
               # For some reason cargoTarpaulin runs the tests in the buildPhase
               buildInputs = kairosNodeAttrs.buildInputs ++ [
                 inputs'.csprpkgs.packages.cctl

--- a/kairos-test-utils/Cargo.toml
+++ b/kairos-test-utils/Cargo.toml
@@ -11,6 +11,10 @@ version.workspace = true
 test = false
 bench = false
 
+[features]
+all-tests = ["cctl-tests"]
+cctl-tests = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 

--- a/kairos-test-utils/src/cctl.rs
+++ b/kairos-test-utils/src/cctl.rs
@@ -133,6 +133,8 @@ impl Drop for CCTLNetwork {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg_attr(not(feature = "cctl-tests"), ignore)]
     #[tokio::test]
     async fn test_cctl_network_starts_and_terminates() {
         let network = CCTLNetwork::run().await.unwrap();


### PR DESCRIPTION
Currently `cargo test` needs to be run inside `nix develop`
Currently we are including integration tests by default when running `cargo test`.

`cctl::tests::test_cctl_network_starts_and_terminates` already takes a very long time.

As we integrate risc0 running all tests will become increasingly untenable.

We should define a default set of fast tests, without `risc0` or `cctl`.

In this pr I add that for only `test_cctl_network_starts_and_terminates`.
When adding slow tests please place them behind a feature and add that feature to `all-tests`

```toml
[features]
all-tests = ["cctl-tests"]
cctl-tests = []
```