### PR TITLE
Final demo contract suggestions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +999,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx"
+version = "1.0.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb497fad022245b29c2a0351df572e2d67c1046bcef2260ebc022aec81efea82"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9327c7f9fbd6329a200a5d4aa6f674c60ab256525ff0084b52a889d4e4c60cee"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2 1.0.79",
+ "quote 1.0.35",
+ "scratch",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c799a4a846f1c0acb9f36bb9c6272d9b3d9457f3633c7753c6057270df13c"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bc249a7e3cd554fd2e8e08a426e9670c50bbfc9a621653cfa9accc9641783"
+dependencies = [
+ "proc-macro2 1.0.79",
+ "quote 1.0.35",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "datasize"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1071,7 @@ dependencies = [
  "casper-execution-engine",
  "casper-types 4.0.1",
  "rand 0.8.5",
+ "wasm-opt",
 ]
 
 [[package]]
@@ -2154,6 +2209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3247,6 +3311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scratch"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
+
+[[package]]
 name = "sd-notify"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3637,6 +3707,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3958,6 +4037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4142,6 +4227,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-opt"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd87a4c135535ffed86123b6fb0f0a5a0bc89e50416c942c5f0662c645f679c"
+dependencies = [
+ "anyhow",
+ "libc",
+ "strum",
+ "strum_macros",
+ "tempfile",
+ "thiserror",
+ "wasm-opt-cxx-sys",
+ "wasm-opt-sys",
+]
+
+[[package]]
+name = "wasm-opt-cxx-sys"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c57b28207aa724318fcec6575fe74803c23f6f266fce10cbc9f3f116762f12e"
+dependencies = [
+ "anyhow",
+ "cxx",
+ "cxx-build",
+ "wasm-opt-sys",
+]
+
+[[package]]
+name = "wasm-opt-sys"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a1cce564dc768dacbdb718fc29df2dba80bd21cb47d8f77ae7e3d95ceb98cbe"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4179,6 +4304,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/demo-contract-tests/Cargo.toml
+++ b/demo-contract-tests/Cargo.toml
@@ -10,3 +10,4 @@ casper-execution-engine = { version = "7.0.0", default-features = false }
 casper-contract = { version = "4.0.0", default-features = false }
 casper-types = { version = "4.0.1", default-features = false }
 rand = "0.8"
+wasm-opt = "0.116"

--- a/demo-contract-tests/Cargo.toml
+++ b/demo-contract-tests/Cargo.toml
@@ -4,11 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dev-dependencies]
-casper-engine-test-support = {version="7.0.0", default-features=false}
-casper-execution-engine = {version="7.0.0", default-features=false}
-casper-contract = {version="4.0.0", default-features=false}
-casper-types = {version="4.0.1", default-features=false}
+casper-engine-test-support = { version = "7.0.0", default-features = false }
+casper-execution-engine = { version = "7.0.0", default-features = false }
+casper-contract = { version = "4.0.0", default-features = false }
+casper-types = { version = "4.0.1", default-features = false }
 rand = "0.8"

--- a/demo-contract-tests/tests/integration_tests.rs
+++ b/demo-contract-tests/tests/integration_tests.rs
@@ -5,7 +5,7 @@ mod tests {
     use casper_types::U512;
 
     #[test]
-    fn should_install_deposit_contract() {
+    fn should_install_contract() {
         let _fixture = TestContext::new();
     }
 

--- a/demo-contract-tests/tests/test_fixture/mod.rs
+++ b/demo-contract-tests/tests/test_fixture/mod.rs
@@ -1,3 +1,5 @@
+mod wasm_helper;
+
 use casper_engine_test_support::{
     ExecuteRequestBuilder, WasmTestBuilder, ARG_AMOUNT, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_ACCOUNT_INITIAL_BALANCE,
@@ -10,12 +12,12 @@ use casper_types::{
     system::{handle_payment::ARG_TARGET, mint::ARG_ID},
     RuntimeArgs, U512,
 };
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use casper_engine_test_support::{InMemoryWasmTestBuilder, PRODUCTION_RUN_GENESIS_REQUEST};
 use casper_types::{ContractHash, URef};
-use std::env;
-use std::fs;
+
+use self::wasm_helper::get_wasm_directory;
 
 pub const ADMIN_SECRET_KEY: [u8; 32] = [1u8; 32];
 
@@ -25,80 +27,6 @@ pub struct TestContext {
     pub admin: AccountHash,
     contract_hash: ContractHash,
     contract_purse: URef,
-}
-
-fn get_wasm_directory() -> PathBuf {
-    // Environment variable or default path.
-    let base_path = if let Ok(custom_path) = env::var("PATH_TO_WASM_BINARIES") {
-        PathBuf::from(custom_path)
-    } else {
-        let project_root = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
-        if cfg!(debug_assertions) {
-            PathBuf::from(project_root)
-                .join("../kairos-contracts/target/wasm32-unknown-unknown/debug/")
-        } else {
-            PathBuf::from(project_root)
-                .join("../kairos-contracts/target/wasm32-unknown-unknown/release/")
-        }
-    };
-    if !base_path.exists() {
-        let build_type = if cfg!(debug_assertions) {
-            "debug"
-        } else {
-            "release"
-        };
-        panic!("WASM directory does not exist: {}. Please build smart contracts at `./kairos-contracts` with `cargo build` for {}.", base_path.display(), build_type);
-    }
-
-    // Ensure all WASM files are optimized.
-    optimize_wasm_files(&base_path).expect("Unable to optimize WASM files");
-
-    base_path
-}
-
-fn optimize_wasm_files(dir: &Path) -> Result<(), String> {
-    let entries = fs::read_dir(dir).map_err(|e| e.to_string())?;
-
-    let mut found_wasm = false;
-    for entry in entries {
-        let entry = entry.map_err(|e| e.to_string())?;
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) == Some("wasm") {
-            found_wasm = true;
-
-            // Skip already optimized files.
-            let file_name = path.file_name().unwrap().to_str().unwrap();
-            if file_name.ends_with("-optimized.wasm") {
-                continue;
-            }
-
-            // Skip if optimized file already exists.
-            let optimized_file_name = format!(
-                "{}-optimized.wasm",
-                file_name.strip_suffix(".wasm").unwrap()
-            );
-            let optimized_file_path = dir.join(&optimized_file_name);
-            if optimized_file_path.exists() {
-                continue;
-            }
-
-            // Optimize and save as new file.
-            let infile = path.to_str().unwrap().to_string();
-            let outfile = optimized_file_path.to_str().unwrap().to_string();
-
-            let mut opts = wasm_opt::OptimizationOptions::new_optimize_for_size();
-            opts.add_pass(wasm_opt::Pass::StripDebug);
-            opts.add_pass(wasm_opt::Pass::SignextLowering);
-
-            opts.run(&infile, &outfile).map_err(|e| e.to_string())?;
-        }
-    }
-
-    if !found_wasm {
-        return Err("No WASM files found in the directory. You should change directory to `./kairos-contracts` and build with `cargo build && cargo build --release`.".to_string());
-    }
-
-    Ok(())
 }
 
 impl TestContext {

--- a/demo-contract-tests/tests/test_fixture/mod.rs
+++ b/demo-contract-tests/tests/test_fixture/mod.rs
@@ -32,19 +32,14 @@ impl TestContext {
         builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
 
         let admin = create_funded_account_for_secret_key_bytes(&mut builder, ADMIN_SECRET_KEY);
-        let deposit_contract_path = std::path::Path::new(env!("PATH_TO_WASM_BINARIES"))
+        let contract_path = std::path::Path::new(env!("PATH_TO_WASM_BINARIES"))
             .join("demo-contract-optimized.wasm");
-        run_session_with_args(
-            &mut builder,
-            &deposit_contract_path,
-            admin,
-            runtime_args! {},
-        );
+        run_session_with_args(&mut builder, &contract_path, admin, runtime_args! {});
 
         let contract_hash = builder
             .get_expected_account(admin)
             .named_keys()
-            .get("kairos_demo_contract")
+            .get("kairos_contract_hash")
             .expect("must have contract hash key as part of contract creation")
             .into_hash()
             .map(ContractHash::new)

--- a/demo-contract-tests/tests/test_fixture/mod.rs
+++ b/demo-contract-tests/tests/test_fixture/mod.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use casper_engine_test_support::{InMemoryWasmTestBuilder, PRODUCTION_RUN_GENESIS_REQUEST};
 use casper_types::{ContractHash, URef};
 use std::env;
+use std::fs;
 
 pub const ADMIN_SECRET_KEY: [u8; 32] = [1u8; 32];
 
@@ -30,19 +31,74 @@ fn get_wasm_directory() -> PathBuf {
     // Environment variable or default path.
     let base_path = if let Ok(custom_path) = env::var("PATH_TO_WASM_BINARIES") {
         PathBuf::from(custom_path)
-    } else if cfg!(debug_assertions) {
-        PathBuf::from("../kairos-contracts/target/wasm32-unknown-unknown/debug/")
     } else {
-        PathBuf::from("../kairos-contracts/target/wasm32-unknown-unknown/release/")
+        let project_root = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+        if cfg!(debug_assertions) {
+            PathBuf::from(project_root)
+                .join("../kairos-contracts/target/wasm32-unknown-unknown/debug/")
+        } else {
+            PathBuf::from(project_root)
+                .join("../kairos-contracts/target/wasm32-unknown-unknown/release/")
+        }
     };
     if !base_path.exists() {
-        panic!("WASM directory does not exist: {}", base_path.display());
+        let build_type = if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        };
+        panic!("WASM directory does not exist: {}. Please build smart contracts at `./kairos-contracts` with `cargo build` for {}.", base_path.display(), build_type);
     }
 
-    // TODO: Ensure all WASM files are optimized
-    //optimize_wasm_files(&base_path)?;
+    // Ensure all WASM files are optimized.
+    optimize_wasm_files(&base_path).expect("Unable to optimize WASM files");
 
     base_path
+}
+
+fn optimize_wasm_files(dir: &Path) -> Result<(), String> {
+    let entries = fs::read_dir(dir).map_err(|e| e.to_string())?;
+
+    let mut found_wasm = false;
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("wasm") {
+            found_wasm = true;
+
+            // Skip already optimized files.
+            let file_name = path.file_name().unwrap().to_str().unwrap();
+            if file_name.ends_with("-optimized.wasm") {
+                continue;
+            }
+
+            // Skip if optimized file already exists.
+            let optimized_file_name = format!(
+                "{}-optimized.wasm",
+                file_name.strip_suffix(".wasm").unwrap()
+            );
+            let optimized_file_path = dir.join(&optimized_file_name);
+            if optimized_file_path.exists() {
+                continue;
+            }
+
+            // Optimize and save as new file.
+            let infile = path.to_str().unwrap().to_string();
+            let outfile = optimized_file_path.to_str().unwrap().to_string();
+
+            let mut opts = wasm_opt::OptimizationOptions::new_optimize_for_size();
+            opts.add_pass(wasm_opt::Pass::StripDebug);
+            opts.add_pass(wasm_opt::Pass::SignextLowering);
+
+            opts.run(&infile, &outfile).map_err(|e| e.to_string())?;
+        }
+    }
+
+    if !found_wasm {
+        return Err("No WASM files found in the directory. You should change directory to `./kairos-contracts` and build with `cargo build && cargo build --release`.".to_string());
+    }
+
+    Ok(())
 }
 
 impl TestContext {

--- a/demo-contract-tests/tests/test_fixture/wasm_helper.rs
+++ b/demo-contract-tests/tests/test_fixture/wasm_helper.rs
@@ -1,0 +1,78 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+pub fn get_wasm_directory() -> PathBuf {
+    // Environment variable or default path.
+    let base_path = if let Ok(custom_path) = env::var("PATH_TO_WASM_BINARIES") {
+        PathBuf::from(custom_path)
+    } else {
+        let project_root = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+        if cfg!(debug_assertions) {
+            PathBuf::from(project_root)
+                .join("../kairos-contracts/target/wasm32-unknown-unknown/debug/")
+        } else {
+            PathBuf::from(project_root)
+                .join("../kairos-contracts/target/wasm32-unknown-unknown/release/")
+        }
+    };
+    if !base_path.exists() {
+        let build_type = if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        };
+        panic!("WASM directory does not exist: {}. Please build smart contracts at `./kairos-contracts` with `cargo build` for {}.", base_path.display(), build_type);
+    }
+
+    // Ensure all WASM files are optimized.
+    optimize_files(&base_path).expect("Unable to optimize WASM files");
+
+    base_path
+}
+
+fn optimize_files(dir: &Path) -> Result<(), String> {
+    let entries = fs::read_dir(dir).map_err(|e| e.to_string())?;
+
+    let mut found_wasm = false;
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("wasm") {
+            found_wasm = true;
+
+            // Skip already optimized files.
+            let file_name = path.file_name().unwrap().to_str().unwrap();
+            if file_name.ends_with("-optimized.wasm") {
+                continue;
+            }
+
+            // Skip if optimized file already exists.
+            let optimized_file_name = format!(
+                "{}-optimized.wasm",
+                file_name.strip_suffix(".wasm").unwrap()
+            );
+            let optimized_file_path = dir.join(&optimized_file_name);
+            if optimized_file_path.exists() {
+                continue;
+            }
+
+            // Optimize and save as new file.
+            let infile = path.to_str().unwrap().to_string();
+            let outfile = optimized_file_path.to_str().unwrap().to_string();
+
+            let mut opts = wasm_opt::OptimizationOptions::new_optimize_for_size();
+            opts.add_pass(wasm_opt::Pass::StripDebug);
+            opts.add_pass(wasm_opt::Pass::SignextLowering);
+
+            opts.run(&infile, &outfile).map_err(|e| e.to_string())?;
+        }
+    }
+
+    if !found_wasm {
+        return Err("No WASM files found in the directory. You should change directory to `./kairos-contracts` and build with `cargo build && cargo build --release`.".to_string());
+    }
+
+    Ok(())
+}

--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,8 @@
       perSystem = { config, self', inputs', system, pkgs, lib, ... }:
         let
           rustToolchain = with inputs'.fenix.packages; combine [
-            latest.toolchain
-            targets.wasm32-unknown-unknown.latest.rust-std
+            stable.toolchain
+            targets.wasm32-unknown-unknown.latest.rust-std # WASM contracts are build with nigthly.
           ];
           craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 

--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,8 @@
       perSystem = { config, self', inputs', system, pkgs, lib, ... }:
         let
           rustToolchain = with inputs'.fenix.packages; combine [
-            stable.toolchain
-            targets.wasm32-unknown-unknown.latest.rust-std # WASM contracts are build with nigthly.
+            latest.toolchain
+            targets.wasm32-unknown-unknown.latest.rust-std
           ];
           craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 

--- a/kairos-contracts/Cargo.lock
+++ b/kairos-contracts/Cargo.lock
@@ -27,12 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,7 +100,7 @@ version = "4.0.1"
 source = "git+https://github.com/cspr-rad/casper-node?branch=kairos-demo-1.5.6#35222130c58b3c9997a358d4248ddae603836496"
 dependencies = [
  "base16",
- "base64 0.13.1",
+ "base64",
  "bitflags",
  "blake2",
  "ed25519-dalek",
@@ -147,7 +141,6 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 name = "contract"
 version = "0.1.0"
 dependencies = [
- "base64 0.20.0",
  "casper-contract",
  "casper-event-standard",
  "casper-types",

--- a/kairos-contracts/Cargo.lock
+++ b/kairos-contracts/Cargo.lock
@@ -67,7 +67,8 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "casper-contract"
 version = "4.0.0"
-source = "git+https://github.com/cspr-rad/casper-node?branch=kairos-demo-1.5.6#35222130c58b3c9997a358d4248ddae603836496"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d42901eb5b09bb79e7d7403642e70983ccac0f4812edf1de77d978abea5f3299"
 dependencies = [
  "casper-types",
  "hex_fmt",
@@ -77,7 +78,8 @@ dependencies = [
 [[package]]
 name = "casper-event-standard"
 version = "0.5.0"
-source = "git+https://github.com/cspr-rad/casper-event-standard?branch=kairos-demo-1.5.6#88b855da23d855d9680816a3dbb4b2e0c4f0ffa7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3a1bdb142b4bfcdceec757422b2e292f446b72ce3613f881eb694f3925ef10"
 dependencies = [
  "casper-contract",
  "casper-event-standard-macro",
@@ -87,7 +89,8 @@ dependencies = [
 [[package]]
 name = "casper-event-standard-macro"
 version = "0.5.0"
-source = "git+https://github.com/cspr-rad/casper-event-standard?branch=kairos-demo-1.5.6#88b855da23d855d9680816a3dbb4b2e0c4f0ffa7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485810e6c8387863a92e9b81e4e66ce290e2c96c0ad8ec4352e95128aa88900e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -97,7 +100,8 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "4.0.1"
-source = "git+https://github.com/cspr-rad/casper-node?branch=kairos-demo-1.5.6#35222130c58b3c9997a358d4248ddae603836496"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e01525b7bbae90fe9de3f1def6ffe05052a94ed7d14b1c2b38baec81eeec31b"
 dependencies = [
  "base16",
  "base64",

--- a/kairos-contracts/Cargo.lock
+++ b/kairos-contracts/Cargo.lock
@@ -39,15 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,7 +148,6 @@ name = "contract"
 version = "0.1.0"
 dependencies = [
  "base64 0.20.0",
- "bincode",
  "casper-contract",
  "casper-event-standard",
  "casper-types",

--- a/kairos-contracts/demo-contract/contract/Cargo.toml
+++ b/kairos-contracts/demo-contract/contract/Cargo.toml
@@ -5,9 +5,9 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", features=["no-std-helpers"]}
-casper-types = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", default-features=false}
-casper-event-standard= {git="https://github.com/cspr-rad/casper-event-standard", branch="kairos-demo-1.5.6", default-features=false}
+casper-contract = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6", features = ["no-std-helpers"] }
+casper-types = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6", default-features = false }
+casper-event-standard = { git = "https://github.com/cspr-rad/casper-event-standard", branch = "kairos-demo-1.5.6", default-features = false }
 
 [build]
 target = "wasm32-unknown-unknown"

--- a/kairos-contracts/demo-contract/contract/Cargo.toml
+++ b/kairos-contracts/demo-contract/contract/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = { version = "4.0.0", features = ["no-std-helpers"] }
+casper-contract = { version = "4.0.0", default-features = false, features = ["no-std-helpers"] }
 casper-types = { version = "4.0.1", default-features = false }
 casper-event-standard = { version = "0.5.0", default-features = false }
 

--- a/kairos-contracts/demo-contract/contract/Cargo.toml
+++ b/kairos-contracts/demo-contract/contract/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", features=["std", "test-support"]}
+casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", features=["std"]}
 casper-types = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", default-features=false}
 casper-event-standard= {git="https://github.com/cspr-rad/casper-event-standard", branch="kairos-demo-1.5.6", default-features=false}
 base64 = { version = "0.20.0", default-features = false, features = ["alloc"] }

--- a/kairos-contracts/demo-contract/contract/Cargo.toml
+++ b/kairos-contracts/demo-contract/contract/Cargo.toml
@@ -5,11 +5,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", features=["std"]}
+casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", features=["no-std-helpers"]}
 casper-types = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", default-features=false}
 casper-event-standard= {git="https://github.com/cspr-rad/casper-event-standard", branch="kairos-demo-1.5.6", default-features=false}
 base64 = { version = "0.20.0", default-features = false, features = ["alloc"] }
-bincode = "1.3.3"
 
 [build]
 target = "wasm32-unknown-unknown"

--- a/kairos-contracts/demo-contract/contract/Cargo.toml
+++ b/kairos-contracts/demo-contract/contract/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", features=["no-std-helpers"]}
 casper-types = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", default-features=false}
 casper-event-standard= {git="https://github.com/cspr-rad/casper-event-standard", branch="kairos-demo-1.5.6", default-features=false}
-base64 = { version = "0.20.0", default-features = false, features = ["alloc"] }
 
 [build]
 target = "wasm32-unknown-unknown"

--- a/kairos-contracts/demo-contract/contract/Cargo.toml
+++ b/kairos-contracts/demo-contract/contract/Cargo.toml
@@ -5,9 +5,9 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6", features = ["no-std-helpers"] }
-casper-types = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6", default-features = false }
-casper-event-standard = { git = "https://github.com/cspr-rad/casper-event-standard", branch = "kairos-demo-1.5.6", default-features = false }
+casper-contract = { version = "4.0.0", features = ["no-std-helpers"] }
+casper-types = { version = "4.0.1", default-features = false }
+casper-event-standard = { version = "0.5.0", default-features = false }
 
 [build]
 target = "wasm32-unknown-unknown"

--- a/kairos-contracts/demo-contract/contract/src/constants.rs
+++ b/kairos-contracts/demo-contract/contract/src/constants.rs
@@ -1,6 +1,6 @@
-pub const KAIROS_DEPOSIT_CONTRACT_HASH: &str = "kairos_demo_contract";
-pub const KAIROS_DEPOSIT_CONTRACT_PACKAGE_HASH: &str = "kairos_contract_package";
-pub const KAIROS_DEPOSIT_CONTRACT_UREF: &str = "demo_contract";
+pub const KAIROS_CONTRACT_HASH: &str = "kairos_contract_hash";
+pub const KAIROS_CONTRACT_PACKAGE_HASH: &str = "kairos_contract_package_hash";
+pub const KAIROS_CONTRACT_UREF: &str = "kairos_contract_uref";
 
 pub const KAIROS_LAST_PROCESSED_DEPOSIT_COUNTER: &str = "last_processed_deposit_counter";
 pub const KAIROS_DEPOSIT_PURSE: &str = "kairos_deposit_purse";

--- a/kairos-contracts/demo-contract/contract/src/constants.rs
+++ b/kairos-contracts/demo-contract/contract/src/constants.rs
@@ -1,6 +1,5 @@
-pub const KAIROS_DEPOSIT_CONTRACT_NAME: &str = "kairos_demo_contract";
-
-pub const KAIROS_DEPOSIT_CONTRACT_PACKAGE: &str = "kairos_contract_package";
+pub const KAIROS_DEPOSIT_CONTRACT_HASH: &str = "kairos_demo_contract";
+pub const KAIROS_DEPOSIT_CONTRACT_PACKAGE_HASH: &str = "kairos_contract_package";
 pub const KAIROS_DEPOSIT_CONTRACT_UREF: &str = "demo_contract";
 
 pub const KAIROS_LAST_PROCESSED_DEPOSIT_COUNTER: &str = "last_processed_deposit_counter";

--- a/kairos-contracts/demo-contract/contract/src/main.rs
+++ b/kairos-contracts/demo-contract/contract/src/main.rs
@@ -14,9 +14,8 @@ use casper_types::{
 };
 mod constants;
 use constants::{
-    KAIROS_DEPOSIT_CONTRACT_HASH, KAIROS_DEPOSIT_CONTRACT_PACKAGE, KAIROS_DEPOSIT_CONTRACT_UREF,
-    KAIROS_DEPOSIT_PURSE, KAIROS_LAST_PROCESSED_DEPOSIT_COUNTER, RUNTIME_ARG_AMOUNT,
-    RUNTIME_ARG_TEMP_PURSE,
+    KAIROS_CONTRACT_HASH, KAIROS_CONTRACT_PACKAGE_HASH, KAIROS_CONTRACT_UREF, KAIROS_DEPOSIT_PURSE,
+    KAIROS_LAST_PROCESSED_DEPOSIT_COUNTER, RUNTIME_ARG_AMOUNT, RUNTIME_ARG_TEMP_PURSE,
 };
 mod entry_points;
 mod utils;
@@ -57,7 +56,7 @@ pub extern "C" fn get_purse() {
 
 // Entry point called by a user through session code to deposit funds.
 // Due to Casper < 2.0 purse management and access control, it is necessary that
-// a temporary purse is funded and passed to the deposit contract, since this is
+// a temporary purse is funded and passed to the contract, since this is
 // the only secure method of making a payment to a contract purse.
 #[no_mangle]
 pub extern "C" fn deposit() {
@@ -100,11 +99,11 @@ pub extern "C" fn call() {
     let (contract_hash, _) = storage::new_locked_contract(
         entry_points,
         Some(named_keys),
-        Some(KAIROS_DEPOSIT_CONTRACT_PACKAGE.to_string()),
-        Some(KAIROS_DEPOSIT_CONTRACT_UREF.to_string()),
+        Some(KAIROS_CONTRACT_PACKAGE_HASH.to_string()),
+        Some(KAIROS_CONTRACT_UREF.to_string()),
     );
     let contract_hash_key = Key::from(contract_hash);
-    runtime::put_key(KAIROS_DEPOSIT_CONTRACT_HASH, contract_hash_key);
+    runtime::put_key(KAIROS_CONTRACT_HASH, contract_hash_key);
 
     let init_args = runtime_args! {};
     // Call the init entry point of the newly installed contract

--- a/kairos-contracts/demo-contract/contract/src/main.rs
+++ b/kairos-contracts/demo-contract/contract/src/main.rs
@@ -100,8 +100,8 @@ pub extern "C" fn call() {
     let (contract_hash, _) = storage::new_locked_contract(
         entry_points,
         Some(named_keys),
-        Some(KAIROS_DEPOSIT_CONTRACT_UREF.to_string()),
         Some(KAIROS_DEPOSIT_CONTRACT_PACKAGE.to_string()),
+        Some(KAIROS_DEPOSIT_CONTRACT_UREF.to_string()),
     );
     let contract_hash_key = Key::from(contract_hash);
     runtime::put_key(KAIROS_DEPOSIT_CONTRACT_NAME, contract_hash_key);

--- a/kairos-contracts/demo-contract/contract/src/main.rs
+++ b/kairos-contracts/demo-contract/contract/src/main.rs
@@ -24,10 +24,7 @@ use utils::errors::DepositError;
 use utils::events::Deposit;
 use utils::get_immediate_caller;
 
-// This entry point is called once when the contract is installed
-// and sets up the security badges with the installer as an admin or the
-// optional list of admins.
-// The optional list of admins is passed to the installation session as a runtime argument.
+// This entry point is called once when the contract is installed.
 // The contract purse will be created in contract context so that it is "owned" by the contract
 // rather than the installing account.
 #[no_mangle]

--- a/kairos-contracts/demo-contract/contract/src/main.rs
+++ b/kairos-contracts/demo-contract/contract/src/main.rs
@@ -14,7 +14,7 @@ use casper_types::{
 };
 mod constants;
 use constants::{
-    KAIROS_DEPOSIT_CONTRACT_NAME, KAIROS_DEPOSIT_CONTRACT_PACKAGE, KAIROS_DEPOSIT_CONTRACT_UREF,
+    KAIROS_DEPOSIT_CONTRACT_HASH, KAIROS_DEPOSIT_CONTRACT_PACKAGE, KAIROS_DEPOSIT_CONTRACT_UREF,
     KAIROS_DEPOSIT_PURSE, KAIROS_LAST_PROCESSED_DEPOSIT_COUNTER, RUNTIME_ARG_AMOUNT,
     RUNTIME_ARG_TEMP_PURSE,
 };
@@ -104,7 +104,7 @@ pub extern "C" fn call() {
         Some(KAIROS_DEPOSIT_CONTRACT_UREF.to_string()),
     );
     let contract_hash_key = Key::from(contract_hash);
-    runtime::put_key(KAIROS_DEPOSIT_CONTRACT_NAME, contract_hash_key);
+    runtime::put_key(KAIROS_DEPOSIT_CONTRACT_HASH, contract_hash_key);
 
     let init_args = runtime_args! {};
     // Call the init entry point of the newly installed contract

--- a/kairos-contracts/demo-contract/contract/src/utils.rs
+++ b/kairos-contracts/demo-contract/contract/src/utils.rs
@@ -1,8 +1,5 @@
-/*
-    The utilities found in this file were scraped from other Casper contracts,
-    mainly cep-78 and cep-18.
-    This file is not necessarily due for review, unless breaking changes are suspected.
-*/
+// Utilities copied from cep-78 and cep-18 implementation.
+
 use casper_contract::contract_api::runtime;
 use casper_types::{system::CallStackElement, Key};
 

--- a/kairos-contracts/demo-contract/deposit-session/Cargo.toml
+++ b/kairos-contracts/demo-contract/deposit-session/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = { version = "4.0.0" }
-casper-types = { version = "4.0.1" }
+casper-contract = { version = "4.0.0", default-features = false }
+casper-types = { version = "4.0.1", default-features = false }
 
 [[bin]]
 name = "deposit-session"

--- a/kairos-contracts/demo-contract/deposit-session/Cargo.toml
+++ b/kairos-contracts/demo-contract/deposit-session/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
-casper-types = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
+casper-contract = { version = "4.0.0" }
+casper-types = { version = "4.0.1" }
 
 [[bin]]
 name = "deposit-session"

--- a/kairos-contracts/demo-contract/deposit-session/Cargo.toml
+++ b/kairos-contracts/demo-contract/deposit-session/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
-casper-types = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
+casper-contract = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
+casper-types = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
 
 [[bin]]
 name = "deposit-session"

--- a/kairos-contracts/demo-contract/deposit-session/Cargo.toml
+++ b/kairos-contracts/demo-contract/deposit-session/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", features=["test-support"]}
+casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
 casper-types = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
 
 [[bin]]

--- a/kairos-contracts/demo-contract/deposit-session/src/main.rs
+++ b/kairos-contracts/demo-contract/deposit-session/src/main.rs
@@ -1,9 +1,9 @@
 /*
-    Transfer native Casper tokens from the caller to the deposit smart contract.
+    Transfer native Casper tokens from the caller to the smart contract.
     Due to the purse access control in Casper 1.5.x, a temporary purse is created and funded
-    by the user first, to then be passed to the deposit contract.
+    by the user first, to then be passed to the contract.
 
-    Finally the temporary purse is emptied / all funds are transferred to the deposit contract's
+    Finally the temporary purse is emptied / all funds are transferred to the contract's
     purse.
 */
 #![no_std]
@@ -16,7 +16,7 @@ pub extern "C" fn call() {
     let contract_hash: ContractHash = runtime::get_named_arg("demo_contract");
     let amount: U512 = runtime::get_named_arg("amount");
     let source: URef = account::get_main_purse();
-    // create a temporary purse that can be passed to the deposit contract
+    // create a temporary purse that can be passed to the contract
     // this is required due to the access control model of the purse system used
     // in casper_node 1.5.x
     // this will likely be drastically changed in 2.0

--- a/kairos-contracts/demo-contract/malicious-reader/Cargo.toml
+++ b/kairos-contracts/demo-contract/malicious-reader/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = { version = "4.0.0" }
-casper-types = { version = "4.0.1" }
+casper-contract = { version = "4.0.0", default-features = false }
+casper-types = { version = "4.0.1", default-features = false }
 
 [[bin]]
 name = "malicious-reader"

--- a/kairos-contracts/demo-contract/malicious-reader/Cargo.toml
+++ b/kairos-contracts/demo-contract/malicious-reader/Cargo.toml
@@ -4,11 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
-casper-types = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
+casper-contract = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
+casper-types = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
 
 [[bin]]
 name = "malicious-reader"

--- a/kairos-contracts/demo-contract/malicious-reader/Cargo.toml
+++ b/kairos-contracts/demo-contract/malicious-reader/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", features=["test-support"]}
+casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
 casper-types = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
 
 [[bin]]

--- a/kairos-contracts/demo-contract/malicious-reader/Cargo.toml
+++ b/kairos-contracts/demo-contract/malicious-reader/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
-casper-types = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
+casper-contract = { version = "4.0.0" }
+casper-types = { version = "4.0.1" }
 
 [[bin]]
 name = "malicious-reader"

--- a/kairos-contracts/demo-contract/malicious-reader/src/main.rs
+++ b/kairos-contracts/demo-contract/malicious-reader/src/main.rs
@@ -1,6 +1,6 @@
 /*
     This session code emulates an attack where a user tries to transfer funds
-    out of the deposit contract's purse, by passing the deposit contract purse as a runtime argument
+    out of the contract's purse, by passing the contract purse as a runtime argument
     and calling transfer_from_purse_to_purse
 */
 

--- a/kairos-contracts/demo-contract/malicious-session/Cargo.toml
+++ b/kairos-contracts/demo-contract/malicious-session/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = { version = "4.0.0" }
-casper-types = { version = "4.0.1" }
+casper-contract = { version = "4.0.0", default-features = false }
+casper-types = { version = "4.0.1", default-features = false }
 
 [[bin]]
 name = "malicious-session"

--- a/kairos-contracts/demo-contract/malicious-session/Cargo.toml
+++ b/kairos-contracts/demo-contract/malicious-session/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
-casper-types = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
+casper-contract = { version = "4.0.0" }
+casper-types = { version = "4.0.1" }
 
 [[bin]]
 name = "malicious-session"

--- a/kairos-contracts/demo-contract/malicious-session/Cargo.toml
+++ b/kairos-contracts/demo-contract/malicious-session/Cargo.toml
@@ -4,11 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
-casper-types = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
+casper-contract = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
+casper-types = { git = "https://github.com/cspr-rad/casper-node", branch = "kairos-demo-1.5.6" }
 
 [[bin]]
 name = "malicious-session"

--- a/kairos-contracts/demo-contract/malicious-session/Cargo.toml
+++ b/kairos-contracts/demo-contract/malicious-session/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6", features=["test-support"]}
+casper-contract = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
 casper-types = {git="https://github.com/cspr-rad/casper-node", branch="kairos-demo-1.5.6"}
 
 [[bin]]

--- a/kairos-contracts/demo-contract/malicious-session/src/main.rs
+++ b/kairos-contracts/demo-contract/malicious-session/src/main.rs
@@ -1,6 +1,6 @@
 /*
     This session code emulates an attack where a user tries to transfer funds
-    out of the deposit contract's purse, by querying the get_purse entry point
+    out of the contract's purse, by querying the get_purse entry point
     and calling transfer_from_purse_to_purse
 */
 

--- a/kairos-test-utils/Cargo.toml
+++ b/kairos-test-utils/Cargo.toml
@@ -15,7 +15,6 @@ bench = false
 all-tests = ["cctl-tests"]
 cctl-tests = []
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 
 [dependencies]


### PR DESCRIPTION
Final suggestions before merging **demo contract**.

###  Refactor Cargo dependencies

- b17471f - Remove unused `base64` dependency.
- 9ec324f - Remove unused `test-support` feature from contract dependency.
- 8d648e4 - Remove unused `bincode` dependency and use `no-std-helpers`.
- 0709c3e - Switch to Casper dependencies from crates.
- 8cf3bc5 - Disable default features where possible.
- 46b1fc4 - Unify format of `Cargo.toml` files.

### Minor fixes/improvements

- 8440fa4 - Remove outdated comment about security badges.
- 757c612 - Fix misplaced args with contract package/uref.
- 25a70d1 - Simplify comment about contract utilities.
- 4bcb72e - Avoid using "deposit contract" name.
- 8010d8e - Stored contract name is actually a contract hash.

### Allow running WASM tests without extra setup

_No longer need to set `PATH_TO_WASM_BINARIES`, install `wasm-opt` or use Nix :face_exhaling:. Just compile contracts, and run integration tests with `cargo test` - it will take care of WASM optimization during runtime._

- fe652c1 - Add `wasm-opt` dependency.
- ce89f53 - Replace compile-time env with helper for WASM directory.
- 6119d49 - Run WASM optimization in tests runtime.
- 42fff34 - Refactor WASM helper for tests.