### PR TITLE
ci: revert removing of check run when PR opened to main #44a7c6e

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
 name: check
 on:
   pull_request:
+    branches: [main]
   push:
     branches: [main]
 


### PR DESCRIPTION
https://github.com/cspr-rad/kairos/commit/44a7c6e76083e86c1f893ada94e6c2b9d1fb2ab1

Revert removed running the ci when a PR is opened to main