### PR TITLE
Build contracts with stable toolchain

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,8 +40,8 @@
       perSystem = { config, self', inputs', system, pkgs, lib, ... }:
         let
           rustToolchain = with inputs'.fenix.packages; combine [
-            latest.toolchain
-            targets.wasm32-unknown-unknown.latest.rust-std
+            stable.toolchain
+            targets.wasm32-unknown-unknown.stable.rust-std
           ];
           craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,8 @@
               filter = path: type: craneLib.filterCargoSources path type;
             };
             cargoExtraArgs = "--target wasm32-unknown-unknown";
-            nativeBuildInputs = [ pkgs.binaryen ];
+            CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_LINKER = "lld";
+            nativeBuildInputs = [ pkgs.binaryen pkgs.lld ];
             doCheck = false;
             # Append "-optimized" to wasm files, to make the tests pass
             postInstall = ''

--- a/kairos-contracts/Cargo.lock
+++ b/kairos-contracts/Cargo.lock
@@ -72,6 +72,13 @@ checksum = "d42901eb5b09bb79e7d7403642e70983ccac0f4812edf1de77d978abea5f3299"
 dependencies = [
  "casper-types",
  "hex_fmt",
+]
+
+[[package]]
+name = "casper-contract-no-std-helpers"
+version = "0.1.0"
+source = "git+https://github.com/koxu1996/casper-contract-no-std-helpers#8a389f3b94e0f950a5912548bdf7ef4c5d859127"
+dependencies = [
  "wee_alloc",
 ]
 
@@ -146,6 +153,7 @@ name = "contract"
 version = "0.1.0"
 dependencies = [
  "casper-contract",
+ "casper-contract-no-std-helpers",
  "casper-event-standard",
  "casper-types",
 ]
@@ -230,6 +238,7 @@ name = "deposit-session"
 version = "0.1.0"
 dependencies = [
  "casper-contract",
+ "casper-contract-no-std-helpers",
  "casper-types",
 ]
 
@@ -407,6 +416,7 @@ name = "malicious-reader"
 version = "0.1.0"
 dependencies = [
  "casper-contract",
+ "casper-contract-no-std-helpers",
  "casper-types",
 ]
 
@@ -415,6 +425,7 @@ name = "malicious-session"
 version = "0.1.0"
 dependencies = [
  "casper-contract",
+ "casper-contract-no-std-helpers",
  "casper-types",
 ]
 

--- a/kairos-contracts/demo-contract/contract/Cargo.toml
+++ b/kairos-contracts/demo-contract/contract/Cargo.toml
@@ -5,7 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-casper-contract = { version = "4.0.0", default-features = false, features = ["no-std-helpers"] }
+casper-contract = { version = "4.0.0", default-features = false }
+casper-contract-no-std-helpers = { version = "0.1.0", "git" = "https://github.com/koxu1996/casper-contract-no-std-helpers"}
 casper-types = { version = "4.0.1", default-features = false }
 casper-event-standard = { version = "0.5.0", default-features = false }
 

--- a/kairos-contracts/demo-contract/contract/src/main.rs
+++ b/kairos-contracts/demo-contract/contract/src/main.rs
@@ -23,6 +23,7 @@ use utils::errors::DepositError;
 use utils::events::Deposit;
 use utils::get_immediate_caller;
 
+#[allow(clippy::single_component_path_imports)]
 #[allow(unused)]
 use casper_contract_no_std_helpers;
 

--- a/kairos-contracts/demo-contract/contract/src/main.rs
+++ b/kairos-contracts/demo-contract/contract/src/main.rs
@@ -23,6 +23,9 @@ use utils::errors::DepositError;
 use utils::events::Deposit;
 use utils::get_immediate_caller;
 
+#[allow(unused)]
+use casper_contract_no_std_helpers;
+
 // This entry point is called once when the contract is installed.
 // The contract purse will be created in contract context so that it is "owned" by the contract
 // rather than the installing account.

--- a/kairos-contracts/demo-contract/deposit-session/Cargo.toml
+++ b/kairos-contracts/demo-contract/deposit-session/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 casper-contract = { version = "4.0.0", default-features = false }
+casper-contract-no-std-helpers = { version = "0.1.0", "git" = "https://github.com/koxu1996/casper-contract-no-std-helpers"}
 casper-types = { version = "4.0.1", default-features = false }
 
 [[bin]]

--- a/kairos-contracts/demo-contract/deposit-session/src/main.rs
+++ b/kairos-contracts/demo-contract/deposit-session/src/main.rs
@@ -11,6 +11,7 @@
 use casper_contract::contract_api::{account, runtime, system};
 use casper_types::{runtime_args, ContractHash, RuntimeArgs, URef, U512};
 
+#[allow(clippy::single_component_path_imports)]
 #[allow(unused)]
 use casper_contract_no_std_helpers;
 

--- a/kairos-contracts/demo-contract/deposit-session/src/main.rs
+++ b/kairos-contracts/demo-contract/deposit-session/src/main.rs
@@ -11,6 +11,9 @@
 use casper_contract::contract_api::{account, runtime, system};
 use casper_types::{runtime_args, ContractHash, RuntimeArgs, URef, U512};
 
+#[allow(unused)]
+use casper_contract_no_std_helpers;
+
 #[no_mangle]
 pub extern "C" fn call() {
     let contract_hash: ContractHash = runtime::get_named_arg("demo_contract");

--- a/kairos-contracts/demo-contract/malicious-reader/Cargo.toml
+++ b/kairos-contracts/demo-contract/malicious-reader/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 casper-contract = { version = "4.0.0", default-features = false }
+casper-contract-no-std-helpers = { version = "0.1.0", "git" = "https://github.com/koxu1996/casper-contract-no-std-helpers"}
 casper-types = { version = "4.0.1", default-features = false }
 
 [[bin]]

--- a/kairos-contracts/demo-contract/malicious-reader/src/main.rs
+++ b/kairos-contracts/demo-contract/malicious-reader/src/main.rs
@@ -9,6 +9,9 @@
 use casper_contract::contract_api::{account, runtime, system};
 use casper_types::{URef, U512};
 
+#[allow(unused)]
+use casper_contract_no_std_helpers;
+
 #[no_mangle]
 pub extern "C" fn call() {
     let amount: U512 = runtime::get_named_arg("amount");

--- a/kairos-contracts/demo-contract/malicious-reader/src/main.rs
+++ b/kairos-contracts/demo-contract/malicious-reader/src/main.rs
@@ -9,6 +9,7 @@
 use casper_contract::contract_api::{account, runtime, system};
 use casper_types::{URef, U512};
 
+#[allow(clippy::single_component_path_imports)]
 #[allow(unused)]
 use casper_contract_no_std_helpers;
 

--- a/kairos-contracts/demo-contract/malicious-session/Cargo.toml
+++ b/kairos-contracts/demo-contract/malicious-session/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 casper-contract = { version = "4.0.0", default-features = false }
+casper-contract-no-std-helpers = { version = "0.1.0", "git" = "https://github.com/koxu1996/casper-contract-no-std-helpers"}
 casper-types = { version = "4.0.1", default-features = false }
 
 [[bin]]

--- a/kairos-contracts/demo-contract/malicious-session/src/main.rs
+++ b/kairos-contracts/demo-contract/malicious-session/src/main.rs
@@ -9,6 +9,9 @@
 use casper_contract::contract_api::{account, runtime, system};
 use casper_types::{runtime_args, ContractHash, RuntimeArgs, URef, U512};
 
+#[allow(unused)]
+use casper_contract_no_std_helpers;
+
 #[no_mangle]
 pub extern "C" fn call() {
     let contract_hash: ContractHash = runtime::get_named_arg("demo_contract");

--- a/kairos-contracts/demo-contract/malicious-session/src/main.rs
+++ b/kairos-contracts/demo-contract/malicious-session/src/main.rs
@@ -9,6 +9,7 @@
 use casper_contract::contract_api::{account, runtime, system};
 use casper_types::{runtime_args, ContractHash, RuntimeArgs, URef, U512};
 
+#[allow(clippy::single_component_path_imports)]
 #[allow(unused)]
 use casper_contract_no_std_helpers;
 

--- a/kairos-contracts/rust-toolchain.toml
+++ b/kairos-contracts/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-04-09"
+channel = "stable"
 components = ["rustc", "rustfmt", "rust-src", "cargo", "clippy", "rust-docs", "rust-analyzer"]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
I extracted `no_std` helpers from `casper-contract` and made it available for stable Rust:

- https://github.com/koxu1996/casper-contract-no-std-helpers/tree/master

Closes #117.