### PR TITLE
`kairos-crypto` - split trait and introduce `no_std` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,7 +2099,6 @@ dependencies = [
  "casper-types 4.0.1",
  "hex",
  "kairos-tx",
- "thiserror",
 ]
 
 [[package]]

--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,11 @@
               cargoExtraArgs = "-p kairos-tx --no-default-features";
             });
 
+            kairos-crypto-no-std = craneLib.buildPackage (kairosNodeAttrs // {
+              cargoArtifacts = self'.packages.kairos-deps;
+              cargoExtraArgs = "-p kairos-crypto --no-default-features --features crypto-casper,tx";
+            });
+
             cctld = pkgs.runCommand "cctld-wrapped"
               {
                 buildInputs = [ pkgs.makeWrapper ];

--- a/kairos-cli/Cargo.toml
+++ b/kairos-cli/Cargo.toml
@@ -23,7 +23,7 @@ casper-types = { version = "3", features = ["std"] } # TODO: Change `std` -> `st
 clap = { version = "4.5", features = ["derive", "deprecated"] }
 hex = "0.4"
 thiserror = "1"
-kairos-crypto = { path = "../kairos-crypto", features = ["fs"] }
+kairos-crypto = { path = "../kairos-crypto", features = ["std"] }
 kairos-tx = { path = "../kairos-tx" }
 kairos-server = { path = "../kairos-server" }
 reqwest = { version = "0.12", features = ["blocking", "json"] }

--- a/kairos-cli/src/commands/transfer.rs
+++ b/kairos-cli/src/commands/transfer.rs
@@ -4,7 +4,7 @@ use crate::utils::parse_hex_string;
 
 use kairos_crypto::error::CryptoError;
 use kairos_crypto::implementations::Signer;
-use kairos_crypto::CryptoSigner;
+use kairos_crypto::SignerCore;
 
 use clap::Parser;
 

--- a/kairos-cli/src/commands/transfer.rs
+++ b/kairos-cli/src/commands/transfer.rs
@@ -5,6 +5,7 @@ use crate::utils::parse_hex_string;
 use kairos_crypto::error::CryptoError;
 use kairos_crypto::implementations::Signer;
 use kairos_crypto::SignerCore;
+use kairos_crypto::SignerFsExtension;
 
 use clap::Parser;
 

--- a/kairos-cli/src/commands/withdraw.rs
+++ b/kairos-cli/src/commands/withdraw.rs
@@ -3,7 +3,7 @@ use crate::error::CliError;
 
 use kairos_crypto::error::CryptoError;
 use kairos_crypto::implementations::Signer;
-use kairos_crypto::SignerCore;
+use kairos_crypto::SignerFsExtension;
 
 use clap::Parser;
 

--- a/kairos-cli/src/commands/withdraw.rs
+++ b/kairos-cli/src/commands/withdraw.rs
@@ -3,7 +3,7 @@ use crate::error::CliError;
 
 use kairos_crypto::error::CryptoError;
 use kairos_crypto::implementations::Signer;
-use kairos_crypto::CryptoSigner;
+use kairos_crypto::SignerCore;
 
 use clap::Parser;
 

--- a/kairos-crypto/Cargo.toml
+++ b/kairos-crypto/Cargo.toml
@@ -15,7 +15,6 @@ fs = ["casper-types/std"] # FUTURE: Change `casper-types/std` -> `casper-types/s
 
 [dependencies]
 hex = { version = "0.4", default-features = false }
-thiserror = "1"
 kairos-tx = { path = "../kairos-tx", optional = true }
 
 # Casper signer implementation.

--- a/kairos-crypto/Cargo.toml
+++ b/kairos-crypto/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 default = ["crypto-casper", "tx"]
 crypto-casper = ["casper-types"]
 tx = ["kairos-tx"]
-fs = ["casper-types/std"] # TODO: Change `std` -> `std-fs-io` in the future version.
+fs = ["casper-types/std"] # FUTURE: Change `casper-types/std` -> `casper-types/std-fs-io` with next types release.
 
 [lib]
 

--- a/kairos-crypto/Cargo.toml
+++ b/kairos-crypto/Cargo.toml
@@ -5,15 +5,16 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-default = ["crypto-casper", "tx"]
+default = ["crypto-casper", "tx", "std"]
 crypto-casper = ["casper-types"]
+std = ["fs"]
 tx = ["kairos-tx"]
 fs = ["casper-types/std"] # FUTURE: Change `casper-types/std` -> `casper-types/std-fs-io` with next types release.
 
 [lib]
 
 [dependencies]
-hex = "0.4"
+hex = { version = "0.4", default-features = false }
 thiserror = "1"
 kairos-tx = { path = "../kairos-tx", optional = true }
 

--- a/kairos-crypto/src/error.rs
+++ b/kairos-crypto/src/error.rs
@@ -1,29 +1,66 @@
-use thiserror::Error;
+use core::fmt;
 
-#[derive(Error, Debug)]
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+
+#[derive(Debug)]
 pub enum CryptoError {
     /// Failed to parse a public key from a raw data.
-    #[error("failed to parse private key: {error}")]
     FailedToParseKey { error: String },
     /// Encoding related error.
-    #[error("failed to serialize '{context}'")]
     Serialization { context: &'static str },
     /// Invalid public key (hexdigest) or other decoding related error.
-    #[error("failed to deserialize '{context}'")]
     Deserialization { context: &'static str },
     /// Signature verification failure.
-    #[error("signature verification failed")]
     InvalidSignature,
     /// Private key is not provided.
-    #[error("private key is not provided")]
     MissingPrivateKey,
-
     /// Unable to compute transaction hash - invalid data given.
     #[cfg(feature = "tx")]
-    #[error("unable to hash transaction data: {error}")]
     TxHashingError { error: String },
     /// Signing algorithm is not available in `kairos-tx`.
     #[cfg(feature = "tx")]
-    #[error("algorithm not available in tx format")]
     InvalidSigningAlgorithm,
 }
+
+impl fmt::Display for CryptoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CryptoError::FailedToParseKey { error } => {
+                write!(f, "failed to parse private key: {error}")
+            }
+            CryptoError::Serialization { context } => write!(f, "failed to serialize '{context}'"),
+            CryptoError::Deserialization { context } => {
+                write!(f, "failed to deserialize '{context}'")
+            }
+            CryptoError::InvalidSignature => write!(f, "signature verification failed"),
+            CryptoError::MissingPrivateKey => write!(f, "private key is not provided"),
+            #[cfg(feature = "tx")]
+            CryptoError::TxHashingError { error } => {
+                write!(f, "unable to hash transaction data: {error}")
+            }
+            #[cfg(feature = "tx")]
+            CryptoError::InvalidSigningAlgorithm => {
+                write!(f, "algorithm not available in tx format")
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+mod error {
+    use super::*;
+    use core::fmt::{Debug, Display};
+
+    #[allow(dead_code)]
+    pub trait Error: Debug + Display {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            None
+        }
+    }
+
+    impl Error for CryptoError {}
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for CryptoError {}

--- a/kairos-crypto/src/implementations/casper.rs
+++ b/kairos-crypto/src/implementations/casper.rs
@@ -6,8 +6,11 @@ use std::path::Path;
 
 extern crate alloc;
 
+#[cfg(all(not(feature = "std"), any(feature = "fs", feature = "tx")))]
+use alloc::string::ToString;
+
 #[cfg(not(feature = "std"))]
-use alloc::{string::ToString, vec::Vec};
+use alloc::vec::Vec;
 
 use crate::CryptoError;
 use crate::SignerCore;

--- a/kairos-crypto/src/implementations/casper.rs
+++ b/kairos-crypto/src/implementations/casper.rs
@@ -4,6 +4,11 @@ use casper_types::{crypto, PublicKey, SecretKey, Signature};
 #[cfg(feature = "fs")]
 use std::path::Path;
 
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::ToString, vec::Vec};
+
 use crate::CryptoError;
 use crate::SignerCore;
 

--- a/kairos-crypto/src/implementations/casper.rs
+++ b/kairos-crypto/src/implementations/casper.rs
@@ -5,14 +5,14 @@ use casper_types::{crypto, PublicKey, SecretKey, Signature};
 use std::path::Path;
 
 use crate::CryptoError;
-use crate::CryptoSigner;
+use crate::SignerCore;
 
 pub struct Signer {
     private_key: Option<SecretKey>,
     public_key: PublicKey,
 }
 
-impl CryptoSigner for Signer {
+impl SignerCore for Signer {
     #[cfg(feature = "fs")]
     fn from_private_key_file<P: AsRef<Path>>(file: P) -> Result<Self, CryptoError>
     where

--- a/kairos-crypto/src/lib.rs
+++ b/kairos-crypto/src/lib.rs
@@ -7,14 +7,6 @@ use std::path::Path;
 use error::CryptoError;
 
 pub trait SignerCore {
-    #[cfg(feature = "fs")]
-    fn from_private_key_file<P: AsRef<Path>>(file: P) -> Result<Self, CryptoError>
-    where
-        Self: Sized;
-    fn from_public_key<T: AsRef<[u8]>>(bytes: T) -> Result<Self, CryptoError>
-    where
-        Self: Sized;
-
     fn sign<T: AsRef<[u8]>>(&self, data: T) -> Result<Vec<u8>, CryptoError>;
     fn verify<T: AsRef<[u8]>, U: AsRef<[u8]>>(
         &self,
@@ -31,4 +23,14 @@ pub trait SignerCore {
     ) -> Result<kairos_tx::asn::Transaction, CryptoError>;
 
     fn to_public_key(&self) -> Result<Vec<u8>, CryptoError>;
+}
+
+#[cfg(feature = "fs")]
+pub trait SignerFsExtension: SignerCore {
+    fn from_private_key_file<P: AsRef<Path>>(file: P) -> Result<Self, CryptoError>
+    where
+        Self: Sized;
+    fn from_public_key<T: AsRef<[u8]>>(bytes: T) -> Result<Self, CryptoError>
+    where
+        Self: Sized;
 }

--- a/kairos-crypto/src/lib.rs
+++ b/kairos-crypto/src/lib.rs
@@ -1,8 +1,15 @@
+#![cfg_attr(all(not(feature = "std"), not(feature = "fs"), not(test)), no_std)]
+
 pub mod error;
 pub mod implementations;
 
 #[cfg(feature = "fs")]
 use std::path::Path;
+
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 use error::CryptoError;
 

--- a/kairos-crypto/src/lib.rs
+++ b/kairos-crypto/src/lib.rs
@@ -14,14 +14,6 @@ pub trait SignerCore {
         signature_bytes: U,
     ) -> Result<(), CryptoError>;
 
-    #[cfg(feature = "tx")]
-    fn verify_tx(&self, tx: kairos_tx::asn::Transaction) -> Result<(), CryptoError>;
-    #[cfg(feature = "tx")]
-    fn sign_tx_payload(
-        &self,
-        payload: kairos_tx::asn::SigningPayload,
-    ) -> Result<kairos_tx::asn::Transaction, CryptoError>;
-
     fn to_public_key(&self) -> Result<Vec<u8>, CryptoError>;
 }
 
@@ -33,4 +25,14 @@ pub trait SignerFsExtension: SignerCore {
     fn from_public_key<T: AsRef<[u8]>>(bytes: T) -> Result<Self, CryptoError>
     where
         Self: Sized;
+}
+
+#[cfg(feature = "tx")]
+pub trait SignerTxExtension: SignerCore {
+    fn verify_tx(&self, tx: kairos_tx::asn::Transaction) -> Result<(), CryptoError>;
+
+    fn sign_tx_payload(
+        &self,
+        payload: kairos_tx::asn::SigningPayload,
+    ) -> Result<kairos_tx::asn::Transaction, CryptoError>;
 }

--- a/kairos-crypto/src/lib.rs
+++ b/kairos-crypto/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use error::CryptoError;
 
-pub trait CryptoSigner {
+pub trait SignerCore {
     #[cfg(feature = "fs")]
     fn from_private_key_file<P: AsRef<Path>>(file: P) -> Result<Self, CryptoError>
     where


### PR DESCRIPTION
This PR moves feature-gated parts of `trait CryptoSigner` into separate traits:
- filesystem extension - https://github.com/cspr-rad/kairos/pull/123/commits/8027d711ddda532892550bfe4c5a44f09f229f65
- transaction extension - https://github.com/cspr-rad/kairos/pull/123/commits/a0950699ec75a4b1ac865cf4b6713b8d88e0e11f

Additionally `no_std` support is introduced - https://github.com/cspr-rad/kairos/pull/123/commits/4684d4fdb2c066179cc6008aba1f56e2d02d8a10.

Closes #86.