### PR TITLE
Use `rasn` fork that is fully compatible with no-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,8 +382,7 @@ dependencies = [
 [[package]]
 name = "bitvec-nom2"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4863ce31b7ff8812568eaffe956024c824d845a1f9f08c329706166c357cae53"
+source = "git+https://github.com/koxu1996/nom-bitvec?branch=bugfix/disable-std-by-default#f7b806749f364bbe4332393f7ac20a57cd461692"
 dependencies = [
  "bitvec 1.0.1",
  "nom",
@@ -2029,12 +2028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jzon"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ab85f84ca42c5ec520e6f3c9966ba1fd62909ce260f8837e248857d2560509"
-
-[[package]]
 name = "k256"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,9 +2978,8 @@ dependencies = [
 
 [[package]]
 name = "rasn"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39df916fdbba892afb9a7e91f4117c58ba36b14a236aa45bfa12fcf623641051"
+version = "0.15.3"
+source = "git+https://github.com/koxu1996/rasn?branch=feature/real-no-std-compatibility#2dee5967f2b314a9ac66fa90b6b73dbaa1deeb36"
 dependencies = [
  "arrayvec",
  "bitvec 1.0.1",
@@ -2995,7 +2987,6 @@ dependencies = [
  "bytes",
  "chrono",
  "either",
- "jzon",
  "konst",
  "nom",
  "num-bigint",
@@ -3008,9 +2999,8 @@ dependencies = [
 
 [[package]]
 name = "rasn-derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e81213825a788a1afeab661c7ecdbaf55c06cefca003a4f1dd14d1d9d854d55"
+version = "0.15.3"
+source = "git+https://github.com/koxu1996/rasn?branch=feature/real-no-std-compatibility#2dee5967f2b314a9ac66fa90b6b73dbaa1deeb36"
 dependencies = [
  "either",
  "itertools 0.10.5",
@@ -3567,7 +3557,6 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
 dependencies = [
- "backtrace",
  "doc-comment",
  "snafu-derive",
 ]

--- a/kairos-prover/Cargo.lock
+++ b/kairos-prover/Cargo.lock
@@ -459,8 +459,7 @@ dependencies = [
 [[package]]
 name = "bitvec-nom2"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4863ce31b7ff8812568eaffe956024c824d845a1f9f08c329706166c357cae53"
+source = "git+https://github.com/koxu1996/nom-bitvec?branch=bugfix/disable-std-by-default#f7b806749f364bbe4332393f7ac20a57cd461692"
 dependencies = [
  "bitvec",
  "nom",
@@ -1465,12 +1464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jzon"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ab85f84ca42c5ec520e6f3c9966ba1fd62909ce260f8837e248857d2560509"
-
-[[package]]
 name = "kairos-circuit-logic"
 version = "0.1.0"
 dependencies = [
@@ -2165,9 +2158,8 @@ dependencies = [
 
 [[package]]
 name = "rasn"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39df916fdbba892afb9a7e91f4117c58ba36b14a236aa45bfa12fcf623641051"
+version = "0.15.3"
+source = "git+https://github.com/koxu1996/rasn?branch=feature/real-no-std-compatibility#2dee5967f2b314a9ac66fa90b6b73dbaa1deeb36"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2175,7 +2167,6 @@ dependencies = [
  "bytes",
  "chrono",
  "either",
- "jzon",
  "konst",
  "nom",
  "num-bigint 0.4.5",
@@ -2188,9 +2179,8 @@ dependencies = [
 
 [[package]]
 name = "rasn-derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e81213825a788a1afeab661c7ecdbaf55c06cefca003a4f1dd14d1d9d854d55"
+version = "0.15.3"
+source = "git+https://github.com/koxu1996/rasn?branch=feature/real-no-std-compatibility#2dee5967f2b314a9ac66fa90b6b73dbaa1deeb36"
 dependencies = [
  "either",
  "itertools 0.10.5",
@@ -2821,7 +2811,6 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
 dependencies = [
- "backtrace",
  "doc-comment",
  "snafu-derive",
 ]

--- a/kairos-tx/Cargo.toml
+++ b/kairos-tx/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
-rasn = { version = "0.14", default-features = false, features = ["macros"] }
+rasn = { version = "0.15", default-features = false, features = ["macros"], git = "https://github.com/koxu1996/rasn", branch = "feature/real-no-std-compatibility" } # TODO: Remove `git` and `branch` once https://github.com/librasn/rasn/issues/262 is fixed.
 sha2 = { version = "0.10", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
`kairos-tx` is mainly based on `rasn`, ASN.1 library that claims to be `no_std`:

![image](https://github.com/cspr-rad/kairos/assets/6506780/df2efbfd-b99e-4861-946e-99a52ac0fa69)

I recently discovered that it implicitly pulls `std` in 3 different ways - described in https://github.com/librasn/rasn/issues/262.

Until it's fixed, I am proposing to use my fork - [see changes here](https://github.com/librasn/rasn/compare/main...koxu1996:rasn:feature/real-no-std-compatibility).

With this PR we get full `no_std` compatibility, proved with:

```
$ rustup target add thumbv7m-none-eabi
$ cargo build -p kairos-tx --no-default-features --target thumbv7m-none-eabi
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
```