### PR TITLE
Fixup deposit counter type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,6 @@ name = "contract-utils"
 version = "0.1.0"
 dependencies = [
  "casper-event-standard",
- "casper-types 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/kairos-contracts/Cargo.lock
+++ b/kairos-contracts/Cargo.lock
@@ -431,7 +431,6 @@ name = "contract-utils"
 version = "0.1.0"
 dependencies = [
  "casper-event-standard",
- "casper-types",
 ]
 
 [[package]]

--- a/kairos-contracts/demo-contract/contract-utils/Cargo.toml
+++ b/kairos-contracts/demo-contract/contract-utils/Cargo.toml
@@ -10,5 +10,4 @@ bench = false
 doctest = false
 
 [dependencies]
-casper-types.workspace = true
 casper-event-standard = { workspace = true, default-features = false }

--- a/kairos-contracts/demo-contract/contract/src/main.rs
+++ b/kairos-contracts/demo-contract/contract/src/main.rs
@@ -136,7 +136,7 @@ pub extern "C" fn call() {
     ]);
 
     // this counter will be udpated by the entry point that processes / verifies batches
-    let last_processed_deposit_counter_uref: URef = storage::new_uref(0u64);
+    let last_processed_deposit_counter_uref: URef = storage::new_uref(0u32);
 
     let initial_trie_root: Option<[u8; 32]> = runtime::get_named_arg(RUNTIME_ARG_INITIAL_TRIE_ROOT);
 


### PR DESCRIPTION
`u64` is not compatible with the casper-event-standard: https://github.com/make-software/casper-event-standard/blob/ad942762a099fc29c0df4cbd3604da8201704195/casper-event-standard/src/contract.rs#L21
We us the last_processed_deposit_index for our deposit window, and we could end up with a much bigger index there than the events length