### PR TITLE
Reduce WASM size to fit into production chainspec

### DIFF
--- a/demo-contract-tests/tests/test_fixture/mod.rs
+++ b/demo-contract-tests/tests/test_fixture/mod.rs
@@ -1,7 +1,7 @@
 mod wasm_helper;
 
 use casper_engine_test_support::{
-    ExecuteRequestBuilder, WasmTestBuilder, ARG_AMOUNT, DEFAULT_ACCOUNT_ADDR,
+    DeployItemBuilder, ExecuteRequestBuilder, WasmTestBuilder, ARG_AMOUNT, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
 use casper_execution_engine::storage::global_state::in_memory::InMemoryGlobalState;
@@ -13,6 +13,7 @@ use casper_types::{
     system::{handle_payment::ARG_TARGET, mint::ARG_ID},
     RuntimeArgs, U512,
 };
+use rand::Rng;
 use std::path::Path;
 
 use casper_engine_test_support::{InMemoryWasmTestBuilder, PRODUCTION_RUN_GENESIS_REQUEST};
@@ -154,11 +155,13 @@ impl TestContext {
         let session_args = runtime_args! {
             "risc0_receipt" => Bytes::from(proof_serialized),
         };
-        let submit_batch_request = ExecuteRequestBuilder::contract_call_by_hash(
+        let payment = U512::from(3_000_000_000_000u64); // 3000 CSPR
+        let submit_batch_request = contract_call_by_hash(
             sender,
             self.contract_hash,
             "submit_batch",
             session_args,
+            payment,
         )
         .build();
         self.builder

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
                   filename=$(basename "$file" .wasm)
                   # Append "-optimized" to the filename and add back the .wasm extension
                   new_filename="$directory$filename-optimized.wasm"
-                  wasm-opt --strip-debug --signext-lowering "$file" -o "$new_filename"
+                  wasm-opt -Oz --strip-debug --signext-lowering "$file" -o "$new_filename"
                 fi
               done
             '';
@@ -121,7 +121,7 @@
                   filename=$(basename "$file" .wasm)
                   # Append "-optimized" to the filename and add back the .wasm extension
                   new_filename="$directory$filename-optimized.wasm"
-                  wasm-opt --strip-debug --signext-lowering "$file" -o "$new_filename"
+                  wasm-opt -Oz --strip-debug --signext-lowering "$file" -o "$new_filename"
                 fi
               done
             '';

--- a/kairos-contracts/Cargo.toml
+++ b/kairos-contracts/Cargo.toml
@@ -17,7 +17,7 @@ codegen-units = 1
 lto = true
 debug = false
 strip = true
-opt-level = 3
+opt-level = 'z'
 panic = "abort"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Context

In Casper v1.5.6 [maximum contract size](https://github.com/casper-network/casper-protocol-release/blob/ce0c03e4b90a2abc0066a2dc13da38d667381423/config/chainspec.toml#L133-L134) is 1 MiB (1,048,576 bytes), which we fairly exceed with demo contract (1.4 MiB), therefore making Kairos incompatible with production network.

## Can we reduce it?

I was suspecting that Risc0 verifier might be the biggest part of final WASM, so I did some tests on [bare minimum contract](https://gist.github.com/koxu1996/9a01db96c632b41268ed0138dd75d01f). However, bare Risc0 verifier (+ bincode2 deserialization for receipt) is less than 20 KB :space_invader:. Casper API calls are also quite small (few kilobytes), so it means we should be able to get way less than 1 MiB.

## First easy optimization

Simple idea: we can enable more aggressive optimization in Rust complier and WASM optimizer.

I run benchmark for WASM produced by `nix build -L --no-link --show-trace .#packages.x86_64-linux.kairos-contracts`:

- Before PR: **1.4MiB** (1,374,581 bytes)
- Setting Rust `o='s'`: **1004KiB** (1,025,823 bytes)
- Setting Rust `o='z'`: **904KiB** (921,813 bytes)
- Setting WASM `o='s'`: **1.3MiB** (1,322,590 bytes)
- Setting WASM `o='z'`: **1.3MiB** (1,320,589 bytes)
- Setting Rust `o='s'` and WASM `o='s'`: **964KiB** (985,116 bytes)
- Setting Rust `o='s'` and WASM `o='z'`: **964KiB** (983,713 bytes)
- Setting Rust `o='z'` and WASM `o='s'`: **868KiB** (886,560 bytes)
- Setting Rust `o='z'` and WASM `o='z'`: **868KiB** (884,798 bytes) :arrow_left: This PR.

After those optimizations we are using 84.77% of production WASM limit :relieved:. Still much, but it was low hanging fruit.
