### PR TITLE
Dehardcode chain name in CLI

### DIFF
--- a/kairos-cli/src/client.rs
+++ b/kairos-cli/src/client.rs
@@ -72,16 +72,12 @@ pub fn deposit(
           "recipient" => recipient
         },
     );
-    let deploy = DeployBuilder::new(
-        chain_name,
-        deposit_session,
-        depositor_secret_key,
-    )
-    .with_standard_payment(MAX_GAS_FEE_PAYMENT_AMOUNT) // max amount allowed to be used on gas fees
-    .with_timestamp(Timestamp::now())
-    .with_ttl(TimeDiff::from_millis(60_000)) // 1 min
-    .build()
-    .map_err(|err| KairosClientError::CasperClientError(err.to_string()))?;
+    let deploy = DeployBuilder::new(chain_name, deposit_session, depositor_secret_key)
+        .with_standard_payment(MAX_GAS_FEE_PAYMENT_AMOUNT) // max amount allowed to be used on gas fees
+        .with_timestamp(Timestamp::now())
+        .with_ttl(TimeDiff::from_millis(60_000)) // 1 min
+        .build()
+        .map_err(|err| KairosClientError::CasperClientError(err.to_string()))?;
 
     let response = reqwest::blocking::Client::new()
         .post(base_url.join(DepositPath::PATH).unwrap())

--- a/kairos-cli/src/client.rs
+++ b/kairos-cli/src/client.rs
@@ -3,6 +3,7 @@ use casper_client::types::{DeployBuilder, DeployHash, ExecutableDeployItem, Time
 use casper_client_types::{crypto::SecretKey, runtime_args, ContractHash, RuntimeArgs, U512};
 use kairos_server::routes::contract_hash::ContractHashPath;
 use kairos_server::routes::deposit::DepositPath;
+use kairos_server::routes::get_chain_name::GetChainNamePath;
 use kairos_server::routes::get_nonce::GetNoncePath;
 use kairos_server::PublicKey;
 use reqwest::Url;
@@ -50,6 +51,7 @@ impl From<reqwest::Error> for KairosClientError {
 pub fn deposit(
     base_url: &Url,
     depositor_secret_key: &SecretKey,
+    chain_name: &str,
     contract_hash: &ContractHash,
     amount: impl Into<U512>,
     recipient: casper_client_types::PublicKey,
@@ -71,7 +73,7 @@ pub fn deposit(
         },
     );
     let deploy = DeployBuilder::new(
-        env!("CASPER_CHAIN_NAME"),
+        chain_name,
         deposit_session,
         depositor_secret_key,
     )
@@ -129,5 +131,18 @@ pub fn contract_hash(base_url: &Url) -> Result<ContractHash, KairosClientError> 
         response
             .json::<ContractHash>()
             .map_err(KairosClientError::from)
+    }
+}
+
+pub fn get_chain_name(base_url: &Url) -> Result<String, KairosClientError> {
+    let response = reqwest::blocking::Client::new()
+        .get(base_url.join(GetChainNamePath::PATH).unwrap())
+        .send()
+        .map_err(KairosClientError::from)?
+        .error_for_status();
+
+    match response {
+        Err(err) => Err(KairosClientError::from(err)),
+        Ok(response) => response.json::<String>().map_err(KairosClientError::from),
     }
 }

--- a/kairos-cli/src/commands/deposit.rs
+++ b/kairos-cli/src/commands/deposit.rs
@@ -1,5 +1,5 @@
 use crate::client;
-use crate::common::args::{AmountArg, ContractHashArg, PrivateKeyPathArg, RecipientArg};
+use crate::common::args::{AmountArg, ChainNameArg, ContractHashArg, PrivateKeyPathArg, RecipientArg};
 use crate::error::CliError;
 
 use casper_client_types::{crypto::SecretKey, ContractHash};
@@ -19,6 +19,8 @@ pub struct Args {
     contract_hash: ContractHashArg,
     #[clap(flatten)]
     recipient: RecipientArg,
+    #[clap(flatten)]
+    chain_name: ChainNameArg,
 }
 
 pub fn run(args: Args, kairos_server_address: Url) -> Result<String, CliError> {
@@ -37,10 +39,15 @@ pub fn run(args: Args, kairos_server_address: Url) -> Result<String, CliError> {
         }
         None => client::contract_hash(&kairos_server_address)?,
     };
+    let chain_name = match args.chain_name.field {
+        None => client::get_chain_name(&kairos_server_address)?,
+        Some(name) => name,
+    };
 
     client::deposit(
         &kairos_server_address,
         &depositor_secret_key,
+        &chain_name,
         &contract_hash,
         amount,
         args.recipient.try_into()?,

--- a/kairos-cli/src/commands/deposit.rs
+++ b/kairos-cli/src/commands/deposit.rs
@@ -1,5 +1,7 @@
 use crate::client;
-use crate::common::args::{AmountArg, ChainNameArg, ContractHashArg, PrivateKeyPathArg, RecipientArg};
+use crate::common::args::{
+    AmountArg, ChainNameArg, ContractHashArg, PrivateKeyPathArg, RecipientArg,
+};
 use crate::error::CliError;
 
 use casper_client_types::{crypto::SecretKey, ContractHash};

--- a/kairos-cli/src/common/args.rs
+++ b/kairos-cli/src/common/args.rs
@@ -52,6 +52,11 @@ impl TryFrom<RecipientArg> for casper_client_types::PublicKey {
 
 #[derive(Args, Debug)]
 pub struct ChainNameArg {
-    #[arg(id = "chain-name", long, value_name = "NAME", help="Name of the chain, to avoid the deploy from being accidentally included in a different chain")]
+    #[arg(
+        id = "chain-name",
+        long,
+        value_name = "NAME",
+        help = "Name of the chain, to avoid the deploy from being accidentally included in a different chain"
+    )]
     pub field: Option<String>,
 }

--- a/kairos-cli/src/common/args.rs
+++ b/kairos-cli/src/common/args.rs
@@ -49,3 +49,9 @@ impl TryFrom<RecipientArg> for casper_client_types::PublicKey {
         Ok(pk)
     }
 }
+
+#[derive(Args, Debug)]
+pub struct ChainNameArg {
+    #[arg(id = "chain-name", long, value_name = "NAME", help="Name of the chain, to avoid the deploy from being accidentally included in a different chain")]
+    pub field: Option<String>,
+}

--- a/kairos-server/src/lib.rs
+++ b/kairos-server/src/lib.rs
@@ -42,6 +42,7 @@ pub fn app_router(state: ServerState) -> Router {
         .typed_post(routes::withdraw_handler)
         .typed_post(routes::transfer_handler)
         .typed_post(routes::deposit_mock_handler)
+        .typed_get(routes::get_chain_name_handler)
         .typed_post(routes::get_nonce_handler)
         .typed_get(routes::contract_hash_handler)
         .with_state(state)

--- a/kairos-server/src/routes/get_chain_name.rs
+++ b/kairos-server/src/routes/get_chain_name.rs
@@ -1,0 +1,18 @@
+use axum::{extract::State, Json};
+use axum_extra::routing::TypedPath;
+use tracing::*;
+
+use crate::{state::ServerState, AppErr};
+
+#[derive(TypedPath, Debug, Clone, Copy)]
+#[typed_path("/api/v1/chain_name")]
+pub struct GetChainNamePath;
+
+#[instrument(level = "trace", skip(_state), ret)]
+pub async fn get_chain_name_handler(
+    _: GetChainNamePath,
+    _state: State<ServerState>,
+) -> Result<Json<String>, AppErr> {
+    let chain_name = env!("CASPER_CHAIN_NAME"); // NOTE: This should be obtained from RPC, rather than from hardcoded value.
+    Ok(Json(String::from(chain_name)))
+}

--- a/kairos-server/src/routes/mod.rs
+++ b/kairos-server/src/routes/mod.rs
@@ -13,9 +13,9 @@ pub use contract_hash::contract_hash_handler;
 pub use deposit::deposit_handler;
 #[cfg(feature = "deposit-mock")]
 pub use deposit_mock::deposit_mock_handler;
-pub use get_chain_name::get_chain_name_handler;
 #[cfg(feature = "database")]
 pub use fetch::query_transactions_handler;
+pub use get_chain_name::get_chain_name_handler;
 pub use get_nonce::get_nonce_handler;
 pub use transfer::transfer_handler;
 pub use withdraw::withdraw_handler;

--- a/kairos-server/src/routes/mod.rs
+++ b/kairos-server/src/routes/mod.rs
@@ -2,6 +2,7 @@ pub mod contract_hash;
 pub mod deposit;
 #[cfg(feature = "deposit-mock")]
 pub mod deposit_mock;
+pub mod get_chain_name;
 pub mod get_nonce;
 pub mod transfer;
 pub mod withdraw;
@@ -12,6 +13,7 @@ pub use contract_hash::contract_hash_handler;
 pub use deposit::deposit_handler;
 #[cfg(feature = "deposit-mock")]
 pub use deposit_mock::deposit_mock_handler;
+pub use get_chain_name::get_chain_name_handler;
 pub use get_nonce::get_nonce_handler;
 pub use transfer::transfer_handler;
 pub use withdraw::withdraw_handler;


### PR DESCRIPTION
This PR fixes #155.

1. Added simple endpoint to Kairos server, that returns chain name:

```
$ curl 127.0.0.1:9999/api/v1/chain_name
"casper-net-1"
```

2. Introduced **optional** `--chain_name` argument for CLI's deposit:

```
$ kairos-cli deposit --help | grep chain
      --chain-name <NAME>              Name of the chain, to avoid the deploy from being accidentally included in a different chain
```

**NOTE:** Help text is based on `casper-client`.

In case chain name is not provided, CLI will query server for it.
