### PR TITLE
Move compile-time `CCTL_CHAINSPEC` and `CCTL_CONFIG` to runtime

### DIFF
--- a/kairos-cli/src/commands/run_cctl.rs
+++ b/kairos-cli/src/commands/run_cctl.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use casper_client_types::{runtime_args, RuntimeArgs};
 use kairos_test_utils::cctl::{CCTLNetwork, DeployableContract};
@@ -16,10 +16,10 @@ pub fn run() -> Result<String, CliError> {
             path: contract_wasm_path,
         };
         println!("Deploying contract...");
-        let chainspec_path = Path::new(env!("CCTL_CHAINSPEC"));
-        let config_path = Path::new(env!("CCTL_CONFIG"));
+        let chainspec_path = PathBuf::from(std::env::var("CCTL_CHAINSPEC").unwrap());
+        let config_path = PathBuf::from(std::env::var("CCTL_CONFIG").unwrap());
 
-        let network = CCTLNetwork::run(None, Some(contract_to_deploy), Some(chainspec_path), Some(config_path))
+        let network = CCTLNetwork::run(None, Some(contract_to_deploy), Some(chainspec_path.as_path()), Some(config_path.as_path()))
             .await
             .unwrap();
 

--- a/kairos-test-utils/src/cctl.rs
+++ b/kairos-test-utils/src/cctl.rs
@@ -76,8 +76,14 @@ impl CCTLNetwork {
         chainspec_path: Option<&Path>,
         config_path: Option<&Path>,
     ) -> anyhow::Result<CCTLNetwork> {
-        let chainspec_path = chainspec_path.unwrap_or_else(|| Path::new(env!("CCTL_CHAINSPEC")));
-        let config_path = config_path.unwrap_or_else(|| Path::new(env!("CCTL_CONFIG")));
+        let chainspec_path: String = chainspec_path
+            .map(|p| p.to_str().unwrap().to_owned())
+            .ok_or_else(|| std::env::var("CCTL_CHAINSPEC"))
+            .unwrap();
+        let config_path: String = config_path
+            .map(|p| p.to_str().unwrap().to_owned())
+            .ok_or_else(|| std::env::var("CCTL_CONFIG"))
+            .unwrap();
 
         let working_dir = working_dir
             .map(|dir| {
@@ -92,9 +98,9 @@ impl CCTLNetwork {
         let mut setup_command = Command::new("cctl-infra-net-setup");
         setup_command.env("CCTL_ASSETS", &assets_dir);
 
-        setup_command.arg(format!("chainspec={}", chainspec_path.to_str().unwrap()));
+        setup_command.arg(format!("chainspec={}", chainspec_path));
 
-        setup_command.arg(format!("config={}", config_path.to_str().unwrap()));
+        setup_command.arg(format!("config={}", config_path));
 
         tracing::info!("Setting up network configuration");
         let output = setup_command

--- a/kairos-test-utils/src/cctl.rs
+++ b/kairos-test-utils/src/cctl.rs
@@ -78,12 +78,10 @@ impl CCTLNetwork {
     ) -> anyhow::Result<CCTLNetwork> {
         let chainspec_path: String = chainspec_path
             .map(|p| p.to_str().unwrap().to_owned())
-            .ok_or_else(|| std::env::var("CCTL_CHAINSPEC"))
-            .unwrap();
+            .unwrap_or_else(|| std::env::var("CCTL_CHAINSPEC").unwrap());
         let config_path: String = config_path
             .map(|p| p.to_str().unwrap().to_owned())
-            .ok_or_else(|| std::env::var("CCTL_CONFIG"))
-            .unwrap();
+            .unwrap_or_else(|| std::env::var("CCTL_CONFIG").unwrap());
 
         let working_dir = working_dir
             .map(|dir| {

--- a/kairos-test-utils/tests/test_cctl_deploys_a_contract_successfully.rs
+++ b/kairos-test-utils/tests/test_cctl_deploys_a_contract_successfully.rs
@@ -30,14 +30,14 @@ async fn test_cctl_deploys_a_contract_successfully() {
         path: contract_wasm_path,
     };
 
-    let chainspec = Path::new(env!("CCTL_CHAINSPEC"));
-    let config = Path::new(env!("CCTL_CONFIG"));
+    let chainspec = PathBuf::from(std::env::var("CCTL_CHAINSPEC").unwrap());
+    let config = PathBuf::from(std::env::var("CCTL_CONFIG").unwrap());
 
     let network = CCTLNetwork::run(
         None,
         Some(contract_to_deploy),
-        Some(chainspec),
-        Some(config),
+        Some(chainspec.as_path()),
+        Some(config.as_path()),
     )
     .await
     .unwrap();

--- a/kairos-test-utils/tests/test_cctl_deploys_a_contract_successfully.rs
+++ b/kairos-test-utils/tests/test_cctl_deploys_a_contract_successfully.rs
@@ -2,7 +2,6 @@ use casper_types::ContractHash;
 use hex::FromHex;
 use kairos_test_utils::cctl::CCTLNetwork;
 use std::fs;
-use std::path::Path;
 use std::path::PathBuf;
 
 use casper_client_types::{runtime_args, RuntimeArgs};

--- a/kairos-test-utils/tests/test_cctl_network_starts_and_terminates.rs
+++ b/kairos-test-utils/tests/test_cctl_network_starts_and_terminates.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::PathBuf;
 
 use casper_client::{get_node_status, rpcs::results::ReactorState, JsonRpcId, Verbosity};
 use kairos_test_utils::cctl::{CCTLNetwork, NodeState};
@@ -16,12 +16,17 @@ fn tracing_init() {
 async fn test_cctl_network_starts_and_terminates() {
     tracing_init();
 
-    let chainspec = Path::new(env!("CCTL_CHAINSPEC"));
-    let config = Path::new(env!("CCTL_CONFIG"));
+    let chainspec = PathBuf::from(std::env::var("CCTL_CHAINSPEC").unwrap());
+    let config = PathBuf::from(std::env::var("CCTL_CONFIG").unwrap());
 
-    let network = CCTLNetwork::run(None, None, Some(chainspec), Some(config))
-        .await
-        .unwrap();
+    let network = CCTLNetwork::run(
+        None,
+        None,
+        Some(chainspec.as_path()),
+        Some(config.as_path()),
+    )
+    .await
+    .unwrap();
 
     for node in &network.nodes {
         if node.state == NodeState::Running {


### PR DESCRIPTION
There is no need to make those env required during compile time. It will help with #171.