### PR TITLE
Dynamic chainname fetch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -178,7 +178,6 @@
               pkgs.postgresql
             ];
 
-            CASPER_CHAIN_NAME = "cspr-dev-cctl";
             PATH_TO_WASM_BINARIES = "${self'.packages.kairos-contracts}/bin";
             PATH_TO_SESSION_BINARIES = "${self'.packages.kairos-session-code}/bin";
             CCTL_CONFIG = "${cctlConfig.config}";
@@ -193,7 +192,6 @@
             # Rust Analyzer needs to be able to find the path to default crate
             RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
             CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_LINKER = "lld";
-            CASPER_CHAIN_NAME = "cspr-dev-cctl";
             PATH_TO_WASM_BINARIES = "${self'.packages.kairos-contracts}/bin";
             PATH_TO_SESSION_BINARIES = "${self'.packages.kairos-session-code}/bin";
             CCTL_CONFIG = "${cctlConfig.config}";

--- a/kairos-server/src/routes/get_chain_name.rs
+++ b/kairos-server/src/routes/get_chain_name.rs
@@ -1,5 +1,6 @@
 use axum::{extract::State, Json};
 use axum_extra::routing::TypedPath;
+use reqwest::Url;
 use tracing::*;
 
 use crate::{state::ServerState, AppErr};
@@ -14,7 +15,7 @@ pub async fn get_chain_name_handler(
     state: State<ServerState>,
 ) -> Result<Json<String>, AppErr> {
     // Call RPC to get chain name.
-    let rpc_url = state.server_config.casper_rpc.as_str();
+    let rpc_url = &state.server_config.casper_rpc;
     let chain_name = get_chain_name_from_rpc(rpc_url)
         .await
         .expect("RPC request failed");
@@ -22,10 +23,10 @@ pub async fn get_chain_name_handler(
     Ok(Json(chain_name))
 }
 
-pub async fn get_chain_name_from_rpc(rpc_url: &str) -> Result<String, ()> {
+pub async fn get_chain_name_from_rpc(rpc_url: &Url) -> Result<String, ()> {
     let request_id = casper_client::JsonRpcId::Number(1);
     let verbosity = casper_client::Verbosity::Low;
-    let response = casper_client::get_node_status(request_id, rpc_url, verbosity)
+    let response = casper_client::get_node_status(request_id, rpc_url.as_str(), verbosity)
         .await
         .expect("RPC request failed");
     let chain_name = response.result.chainspec_name;

--- a/kairos-server/src/routes/get_chain_name.rs
+++ b/kairos-server/src/routes/get_chain_name.rs
@@ -15,7 +15,9 @@ pub async fn get_chain_name_handler(
 ) -> Result<Json<String>, AppErr> {
     // Call RPC to get chain name.
     let rpc_url = state.server_config.casper_rpc.as_str();
-    let chain_name = get_chain_name_from_rpc(rpc_url).await.expect("RPC request failed");
+    let chain_name = get_chain_name_from_rpc(rpc_url)
+        .await
+        .expect("RPC request failed");
 
     Ok(Json(chain_name))
 }
@@ -23,7 +25,9 @@ pub async fn get_chain_name_handler(
 pub async fn get_chain_name_from_rpc(rpc_url: &str) -> Result<String, ()> {
     let request_id = casper_client::JsonRpcId::Number(1);
     let verbosity = casper_client::Verbosity::Low;
-    let response = casper_client::get_node_status(request_id, rpc_url, verbosity).await.expect("RPC request failed");
+    let response = casper_client::get_node_status(request_id, rpc_url, verbosity)
+        .await
+        .expect("RPC request failed");
     let chain_name = response.result.chainspec_name;
 
     Ok(chain_name)

--- a/kairos-server/src/routes/get_chain_name.rs
+++ b/kairos-server/src/routes/get_chain_name.rs
@@ -16,3 +16,12 @@ pub async fn get_chain_name_handler(
     let chain_name = env!("CASPER_CHAIN_NAME"); // NOTE: This should be obtained from RPC, rather than from hardcoded value.
     Ok(Json(String::from(chain_name)))
 }
+
+pub async fn get_chain_name_from_rpc(rpc_url: &str) -> Result<String, ()> {
+    let request_id = casper_client::JsonRpcId::Number(1);
+    let verbosity = casper_client::Verbosity::Low;
+    let response = casper_client::get_node_status(request_id, rpc_url, verbosity).await.expect("RPC request failed");
+    let chain_name = response.result.chainspec_name;
+
+    Ok(chain_name)
+}

--- a/kairos-server/src/routes/get_chain_name.rs
+++ b/kairos-server/src/routes/get_chain_name.rs
@@ -8,13 +8,16 @@ use crate::{state::ServerState, AppErr};
 #[typed_path("/api/v1/chain_name")]
 pub struct GetChainNamePath;
 
-#[instrument(level = "trace", skip(_state), ret)]
+#[instrument(level = "trace", skip(state), ret)]
 pub async fn get_chain_name_handler(
     _: GetChainNamePath,
-    _state: State<ServerState>,
+    state: State<ServerState>,
 ) -> Result<Json<String>, AppErr> {
-    let chain_name = env!("CASPER_CHAIN_NAME"); // NOTE: This should be obtained from RPC, rather than from hardcoded value.
-    Ok(Json(String::from(chain_name)))
+    // Call RPC to get chain name.
+    let rpc_url = state.server_config.casper_rpc.as_str();
+    let chain_name = get_chain_name_from_rpc(rpc_url).await.expect("RPC request failed");
+
+    Ok(Json(chain_name))
 }
 
 pub async fn get_chain_name_from_rpc(rpc_url: &str) -> Result<String, ()> {

--- a/kairos-server/src/state/submit_batch.rs
+++ b/kairos-server/src/state/submit_batch.rs
@@ -31,7 +31,7 @@ pub async fn submit_proof_to_contract(
         },
     };
 
-    let chain_name = get_chain_name_from_rpc(casper_rpc.as_str())
+    let chain_name = get_chain_name_from_rpc(&casper_rpc)
         .await
         .expect("RPC request failed");
     let deploy = DeployBuilder::new(chain_name, submit_batch, signer)

--- a/kairos-server/src/state/submit_batch.rs
+++ b/kairos-server/src/state/submit_batch.rs
@@ -22,7 +22,9 @@ pub async fn submit_proof_to_contract(
         },
     };
 
-    let chain_name = get_chain_name_from_rpc(casper_rpc.as_str()).await.expect("RPC request failed");
+    let chain_name = get_chain_name_from_rpc(casper_rpc.as_str())
+        .await
+        .expect("RPC request failed");
     let deploy = DeployBuilder::new(chain_name, submit_batch, signer)
         .with_standard_payment(MAX_GAS_FEE_PAYMENT_AMOUNT)
         .with_timestamp(Timestamp::now())

--- a/kairos-server/src/state/submit_batch.rs
+++ b/kairos-server/src/state/submit_batch.rs
@@ -3,6 +3,8 @@ use casper_client_types::{bytesrepr::Bytes, runtime_args, ContractHash, RuntimeA
 use rand::random;
 use reqwest::Url;
 
+use crate::routes::get_chain_name::get_chain_name_from_rpc;
+
 pub const MAX_GAS_FEE_PAYMENT_AMOUNT: u64 = 10_000_000_000_000;
 
 // TODO: retry request on failure, improve error handling
@@ -20,7 +22,8 @@ pub async fn submit_proof_to_contract(
         },
     };
 
-    let deploy = DeployBuilder::new(env!("CASPER_CHAIN_NAME"), submit_batch, signer)
+    let chain_name = get_chain_name_from_rpc(casper_rpc.as_str()).await.expect("RPC request failed");
+    let deploy = DeployBuilder::new(chain_name, submit_batch, signer)
         .with_standard_payment(MAX_GAS_FEE_PAYMENT_AMOUNT)
         .with_timestamp(Timestamp::now())
         .with_ttl(TimeDiff::from_millis(60_000))


### PR DESCRIPTION
This PR gets rid of `CASPER_CHAIN_NAME` env variable - it gets fetched dynamically from RPC. In the future we could introduce cache for it.